### PR TITLE
Add Empirical Kullback Leibler

### DIFF
--- a/docs/source/losses.rst
+++ b/docs/source/losses.rst
@@ -43,15 +43,15 @@ Expectation
 Entropy
 --------
 
-CrossEntropy
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: CrossEntropy
-
 Entropy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: Entropy
+
+CrossEntropy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: CrossEntropy
 
 StochasticReconstructionLoss
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/losses.rst
+++ b/docs/source/losses.rst
@@ -43,10 +43,17 @@ Expectation
 Entropy
 --------
 
-CrossEntropy
+EmpiricalCrossEntropy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: CrossEntropy
+.. autoclass:: EmpiricalCrossEntropy
+    :members:
+    :undoc-members:
+
+EmpiricalEntropy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: EmpiricalEntropy
     :members:
     :undoc-members:
 
@@ -54,13 +61,6 @@ Entropy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: Entropy
-    :members:
-    :undoc-members:
-
-AnalyticalEntropy
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: AnalyticalEntropy
     :members:
     :undoc-members:
 
@@ -83,6 +83,13 @@ ELBO
 
 Statistical distance
 ----------------------------
+
+EmpiricalKullbackLeibler
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: EmpiricalKullbackLeibler
+    :members:
+    :undoc-members:
 
 KullbackLeibler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/losses.rst
+++ b/docs/source/losses.rst
@@ -43,33 +43,20 @@ Expectation
 Entropy
 --------
 
-EmpiricalCrossEntropy
+CrossEntropy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: EmpiricalCrossEntropy
-    :members:
-    :undoc-members:
-
-EmpiricalEntropy
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: EmpiricalEntropy
-    :members:
-    :undoc-members:
+.. autofunction:: CrossEntropy
 
 Entropy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: Entropy
-    :members:
-    :undoc-members:
+.. autofunction:: Entropy
 
 StochasticReconstructionLoss
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: StochasticReconstructionLoss
-    :members:
-    :undoc-members:
+.. autofunction:: StochasticReconstructionLoss
 
 Lower bound
 ----------------------------
@@ -77,26 +64,15 @@ Lower bound
 ELBO
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: ELBO
-    :members:
-    :undoc-members:
+.. autofunction:: ELBO
 
 Statistical distance
 ----------------------------
 
-EmpiricalKullbackLeibler
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: EmpiricalKullbackLeibler
-    :members:
-    :undoc-members:
-
 KullbackLeibler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: KullbackLeibler
-    :members:
-    :undoc-members:
+.. autofunction:: KullbackLeibler
 
 WassersteinDistance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -156,13 +132,6 @@ Parameter
 
 .. currentmodule:: pixyz.losses.losses
 .. autoclass:: Parameter
-    :members:
-    :undoc-members:
-
-SetLoss
-~~~~~~~~~~~
-
-.. autoclass:: SetLoss
     :members:
     :undoc-members:
 

--- a/examples/mmd_vae.ipynb
+++ b/examples/mmd_vae.ipynb
@@ -60,7 +60,7 @@
    "outputs": [],
    "source": [
     "from pixyz.distributions import Normal, Bernoulli, DataDistribution\n",
-    "from pixyz.losses import EmpiricalCrossEntropy, MMD\n",
+    "from pixyz.losses import CrossEntropy, MMD\n",
     "from pixyz.models import Model\n",
     "from pixyz.utils import print_latex"
    ]
@@ -229,7 +229,7 @@
     }
    ],
    "source": [
-    "loss_cls = EmpiricalCrossEntropy(q, p).mean() + MMD(q_mg, prior, kernel=\"gaussian\", sigma_sqr=z_dim/2.)\n",
+    "loss_cls = CrossEntropy(q, p).mean() + MMD(q_mg, prior, kernel=\"gaussian\", sigma_sqr=z_dim/2.)\n",
     "print(loss_cls)\n",
     "print_latex(loss_cls)"
    ]

--- a/examples/mmd_vae.ipynb
+++ b/examples/mmd_vae.ipynb
@@ -60,7 +60,7 @@
    "outputs": [],
    "source": [
     "from pixyz.distributions import Normal, Bernoulli, DataDistribution\n",
-    "from pixyz.losses import CrossEntropy, MMD\n",
+    "from pixyz.losses import EmpiricalCrossEntropy, MMD\n",
     "from pixyz.models import Model\n",
     "from pixyz.utils import print_latex"
    ]
@@ -229,7 +229,7 @@
     }
    ],
    "source": [
-    "loss_cls = CrossEntropy(q, p).mean() + MMD(q_mg, prior, kernel=\"gaussian\", sigma_sqr=z_dim/2.)\n",
+    "loss_cls = EmpiricalCrossEntropy(q, p).mean() + MMD(q_mg, prior, kernel=\"gaussian\", sigma_sqr=z_dim/2.)\n",
     "print(loss_cls)\n",
     "print_latex(loss_cls)"
    ]
@@ -677,6 +677,15 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.2"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [],
+    "metadata": {
+     "collapsed": false
+    }
+   }
   }
  },
  "nbformat": 4,

--- a/pixyz/__init__.py
+++ b/pixyz/__init__.py
@@ -1,2 +1,2 @@
 name = "pixyz"
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/pixyz/losses/__init__.py
+++ b/pixyz/losses/__init__.py
@@ -3,9 +3,8 @@ from .divergences import (
 )
 
 from .entropy import (
-    EmpiricalCrossEntropy,
-    EmpiricalEntropy,
     Entropy,
+    CrossEntropy,
     StochasticReconstructionLoss,
 )
 
@@ -43,9 +42,8 @@ from .wasserstein import (
 
 __all__ = [
     'Parameter',
-    'EmpiricalCrossEntropy',
-    'EmpiricalEntropy',
     'Entropy',
+    'CrossEntropy',
     'StochasticReconstructionLoss',
     'Expectation',
     'KullbackLeibler',

--- a/pixyz/losses/__init__.py
+++ b/pixyz/losses/__init__.py
@@ -3,9 +3,9 @@ from .divergences import (
 )
 
 from .entropy import (
-    CrossEntropy,
+    EmpiricalCrossEntropy,
+    EmpiricalEntropy,
     Entropy,
-    AnalyticalEntropy,
     StochasticReconstructionLoss,
 )
 
@@ -43,9 +43,9 @@ from .wasserstein import (
 
 __all__ = [
     'Parameter',
-    'CrossEntropy',
+    'EmpiricalCrossEntropy',
+    'EmpiricalEntropy',
     'Entropy',
-    'AnalyticalEntropy',
     'StochasticReconstructionLoss',
     'Expectation',
     'KullbackLeibler',

--- a/pixyz/losses/adversarial_loss.py
+++ b/pixyz/losses/adversarial_loss.py
@@ -291,8 +291,8 @@ class AdversarialKullbackLeibler(AdversarialLoss):
 
     .. math::
 
-        D_{KL}[p(x)||q(x)] = \mathbb{E}_{p(x)}[\log \frac{p(x)}{q(x)}]
-         \approx \mathbb{E}_{p(x)}[\log \frac{d^*(x)}{1-d^*(x)}],
+        D_{KL}[p(x)||q(x)] = \mathbb{E}_{p(x)}\left[\log \frac{p(x)}{q(x)}\right]
+         \approx \mathbb{E}_{p(x)}\left[\log \frac{d^*(x)}{1-d^*(x)}\right],
 
     where :math:`d^*(x) = \arg\max_{d} \mathbb{E}_{q(x)}[\log d(x)] + \mathbb{E}_{p(x)}[\log (1-d(x))]`.
 

--- a/pixyz/losses/divergences.py
+++ b/pixyz/losses/divergences.py
@@ -12,8 +12,8 @@ def KullbackLeibler(p, q, input_var=None, dim=None, analytical=True):
 
     .. math::
 
-        D_{KL}[p||q] = \mathbb{E}_{p(x)}[\log \frac{p(x)}{q(x)}] \approx \frac{1}{L}\sum_{l=1}^L \log\frac{p(x_l)}{q(x_l)}
-    where :math:`x_l \sim p(x)`.
+        D_{KL}[p||q] &= \mathbb{E}_{p(x)}[\log \frac{p(x)}{q(x)}] \qquad \text{(analytical)}\\
+        &\approx \frac{1}{L}\sum_{l=1}^L \log\frac{p(x_l)}{q(x_l)}, \quad \text{where} \quad  x_l \sim p(x) \quad \text{(MC approximation)}.
 
     Note:
         This class is a special case of the :attr:`Expectation` class if analytical=False.
@@ -23,12 +23,12 @@ def KullbackLeibler(p, q, input_var=None, dim=None, analytical=True):
     >>> import torch
     >>> from pixyz.distributions import Normal, Beta
     >>> p = Normal(loc=torch.tensor(0.), scale=torch.tensor(1.), var=["z"], features_shape=[64], name="p")
-    >>> q = Beta(concentration0=torch.tensor(1.), concentration1=torch.tensor(1.),
-    ...          var=["z"], features_shape=[64], name="q")
-    >>> loss_cls = KullbackLeibler(p, q)
+    >>> q = Normal(loc=torch.tensor(1.), scale=torch.tensor(1.), var=["z"], features_shape=[64], name="q")
+    >>> loss_cls = KullbackLeibler(p, q, analytical=True)
     >>> print(loss_cls)
     D_{KL} \left[p(z)||q(z) \right]
-    >>> loss = loss_cls.eval()
+    >>> loss_cls.eval()
+    tensor([32.])
     >>> loss_cls = KullbackLeibler(p, q, analytical=False)
     >>> print(loss_cls)
     \mathbb{E}_{p(z)} \left[\log p(z) - \log q(z) \right]

--- a/pixyz/losses/divergences.py
+++ b/pixyz/losses/divergences.py
@@ -6,14 +6,15 @@ from ..utils import get_dict_values
 from .losses import Loss
 
 
-def KullbackLeibler(p, q, input_var=None, dim=None, analytical=True):
+def KullbackLeibler(p, q, input_var=None, dim=None, analytical=True, sample_shape=torch.Size([1])):
     r"""
     Kullback-Leibler divergence (analytical or Monte Carlo Apploximation).
 
     .. math::
 
-        D_{KL}[p||q] &= \mathbb{E}_{p(x)}[\log \frac{p(x)}{q(x)}] \qquad \text{(analytical)}\\
-        &\approx \frac{1}{L}\sum_{l=1}^L \log\frac{p(x_l)}{q(x_l)}, \quad \text{where} \quad  x_l \sim p(x) \quad \text{(MC approximation)}.
+        D_{KL}[p||q] &= \mathbb{E}_{p(x)}\left[\log \frac{p(x)}{q(x)}\right] \qquad \text{(analytical)}\\
+        &\approx \frac{1}{L}\sum_{l=1}^L \log\frac{p(x_l)}{q(x_l)},
+         \quad \text{where} \quad  x_l \sim p(x) \quad \text{(MC approximation)}.
 
     Examples
     --------
@@ -26,11 +27,11 @@ def KullbackLeibler(p, q, input_var=None, dim=None, analytical=True):
     D_{KL} \left[p(z)||q(z) \right]
     >>> loss_cls.eval()
     tensor([32.])
-    >>> loss_cls = KullbackLeibler(p, q, analytical=False)
+    >>> loss_cls = KullbackLeibler(p, q, analytical=False, sample_shape=[64])
     >>> print(loss_cls)
     \mathbb{E}_{p(z)} \left[\log p(z) - \log q(z) \right]
     >>> loss_cls.eval() # doctest: +SKIP
-    tensor([29.1984])
+    tensor([31.4713])
     """
     if input_var is None:
         input_var = p.input_var
@@ -38,7 +39,7 @@ def KullbackLeibler(p, q, input_var=None, dim=None, analytical=True):
     if analytical:
         loss = AnalyticalKullbackLeibler(p, q, input_var, dim)
     else:
-        loss = (p.log_prob() - q.log_prob()).expectation(p, input_var)
+        loss = (p.log_prob() - q.log_prob()).expectation(p, input_var, sample_shape=sample_shape)
     return loss
 
 

--- a/pixyz/losses/divergences.py
+++ b/pixyz/losses/divergences.py
@@ -15,9 +15,6 @@ def KullbackLeibler(p, q, input_var=None, dim=None, analytical=True):
         D_{KL}[p||q] &= \mathbb{E}_{p(x)}[\log \frac{p(x)}{q(x)}] \qquad \text{(analytical)}\\
         &\approx \frac{1}{L}\sum_{l=1}^L \log\frac{p(x_l)}{q(x_l)}, \quad \text{where} \quad  x_l \sim p(x) \quad \text{(MC approximation)}.
 
-    Note:
-        This class is a special case of the :attr:`Expectation` class if analytical=False.
-
     Examples
     --------
     >>> import torch

--- a/pixyz/losses/divergences.py
+++ b/pixyz/losses/divergences.py
@@ -29,7 +29,8 @@ def KullbackLeibler(p, q, input_var=None, dim=None, analytical=True):
     >>> loss_cls = KullbackLeibler(p, q, analytical=False)
     >>> print(loss_cls)
     \mathbb{E}_{p(z)} \left[\log p(z) - \log q(z) \right]
-    >>> loss = loss_cls.eval()
+    >>> loss_cls.eval() # doctest: +SKIP
+    tensor([29.1984])
     """
     if input_var is None:
         input_var = p.input_var

--- a/pixyz/losses/elbo.py
+++ b/pixyz/losses/elbo.py
@@ -6,9 +6,8 @@ def ELBO(p, q, input_var=None):
 
     .. math::
 
-        \mathbb{E}_{q(z|x)}[\log \frac{p(x,z)}{q(z|x)}] \approx \frac{1}{L}\sum_{l=1}^L \log p(x, z_l),
-
-    where :math:`z_l \sim q(z|x)`.
+        \mathbb{E}_{q(z|x)}\left[\log \frac{p(x,z)}{q(z|x)}\right] \approx \frac{1}{L}\sum_{l=1}^L \log p(x, z_l),
+         \quad \text{where} \quad z_l \sim q(z|x).
 
     Note:
         This class is a special case of the :attr:`Expectation` class.

--- a/pixyz/losses/elbo.py
+++ b/pixyz/losses/elbo.py
@@ -1,6 +1,7 @@
+import torch
 
 
-def ELBO(p, q, input_var=None):
+def ELBO(p, q, input_var=None, sample_shape=torch.Size([1])):
     r"""
     The evidence lower bound (Monte Carlo approximation).
 
@@ -23,5 +24,5 @@ def ELBO(p, q, input_var=None):
     \mathbb{E}_{p(z|x)} \left[\log p(x|z) - \log p(z|x) \right]
     >>> loss = loss_cls.eval({"x": torch.randn(1, 64)})
     """
-    loss = (p.log_prob() - q.log_prob()).expectation(q, input_var)
+    loss = (p.log_prob() - q.log_prob()).expectation(q, input_var, sample_shape=sample_shape)
     return loss

--- a/pixyz/losses/elbo.py
+++ b/pixyz/losses/elbo.py
@@ -1,7 +1,6 @@
-from .losses import SetLoss
 
 
-class ELBO(SetLoss):
+def ELBO(p, q, input_var=None):
     r"""
     The evidence lower bound (Monte Carlo approximation).
 
@@ -25,7 +24,5 @@ class ELBO(SetLoss):
     \mathbb{E}_{p(z|x)} \left[\log p(x|z) - \log p(z|x) \right]
     >>> loss = loss_cls.eval({"x": torch.randn(1, 64)})
     """
-    def __init__(self, p, q, input_var=None):
-
-        loss = (p.log_prob() - q.log_prob()).expectation(q, input_var)
-        super().__init__(loss)
+    loss = (p.log_prob() - q.log_prob()).expectation(q, input_var)
+    return loss

--- a/pixyz/losses/entropy.py
+++ b/pixyz/losses/entropy.py
@@ -13,9 +13,6 @@ def Entropy(p, input_var=None, analytical=True):
         H[p] &= -\mathbb{E}_{p(x)}[\log p(x)] \qquad \text{(analytical)}\\
         &\approx -\frac{1}{L}\sum_{l=1}^L \log p(x_l), \quad \text{where} \quad x_l \sim p(x) \quad \text{(MC approximation)}.
 
-    Note:
-        This class is a special case of the :attr:`Expectation` class if analytical=False.
-
     Examples
     --------
     >>> import torch
@@ -64,9 +61,6 @@ def CrossEntropy(p, q, input_var=None, analytical=False):
 
         H[p||q] &= -\mathbb{E}_{p(x)}[\log q(x)] \qquad \text{(analytical)}\\
         &\approx -\frac{1}{L}\sum_{l=1}^L \log q(x_l), \quad \text{where} \quad x_l \sim p(x) \quad \text{(MC approximation)}.
-
-    Note:
-        This class is a special case of the :attr:`Expectation` class if analytical=False.
 
     Examples
     --------

--- a/pixyz/losses/entropy.py
+++ b/pixyz/losses/entropy.py
@@ -10,7 +10,7 @@ def Entropy(p, input_var=None, analytical=True):
 
     .. math::
 
-        H[p] &= -\mathbb{E}_{p(x)}[\log p(x)] \qquad \text{(analytical)}\\
+        H(p) &= -\mathbb{E}_{p(x)}[\log p(x)] \qquad \text{(analytical)}\\
         &\approx -\frac{1}{L}\sum_{l=1}^L \log p(x_l), \quad \text{where} \quad x_l \sim p(x) \quad \text{(MC approximation)}.
 
     Examples
@@ -59,7 +59,7 @@ def CrossEntropy(p, q, input_var=None, analytical=False):
 
     .. math::
 
-        H[p||q] &= -\mathbb{E}_{p(x)}[\log q(x)] \qquad \text{(analytical)}\\
+        H(p,q) &= -\mathbb{E}_{p(x)}[\log q(x)] \qquad \text{(analytical)}\\
         &\approx -\frac{1}{L}\sum_{l=1}^L \log q(x_l), \quad \text{where} \quad x_l \sim p(x) \quad \text{(MC approximation)}.
 
     Examples

--- a/pixyz/losses/entropy.py
+++ b/pixyz/losses/entropy.py
@@ -91,7 +91,7 @@ def CrossEntropy(p, q, input_var=None, analytical=False, sample_shape=torch.Size
     return loss
 
 
-def StochasticReconstructionLoss(encoder, decoder, input_var=None):
+def StochasticReconstructionLoss(encoder, decoder, input_var=None, sample_shape=torch.Size([1])):
     r"""
     Reconstruction Loss (Monte Carlo approximation).
 
@@ -123,5 +123,5 @@ def StochasticReconstructionLoss(encoder, decoder, input_var=None):
                                                                      decoder.__class__.__name__,
                                                                      encoder.__class__.__name__))
 
-    loss = -decoder.log_prob().expectation(encoder, input_var)
+    loss = -decoder.log_prob().expectation(encoder, input_var, sample_shape=sample_shape)
     return loss

--- a/pixyz/losses/entropy.py
+++ b/pixyz/losses/entropy.py
@@ -10,9 +10,8 @@ def Entropy(p, input_var=None, analytical=True):
 
     .. math::
 
-        H[p] = -\mathbb{E}_{p(x)}[\log p(x)] \approx -\frac{1}{L}\sum_{l=1}^L \log p(x_l),
-
-    where :math:`x_l \sim p(x)`.
+        H[p] &= -\mathbb{E}_{p(x)}[\log p(x)] \qquad \text{(analytical)}\\
+        &\approx -\frac{1}{L}\sum_{l=1}^L \log p(x_l), \quad \text{where} \quad x_l \sim p(x) \quad \text{(MC approximation)}.
 
     Note:
         This class is a special case of the :attr:`Expectation` class if analytical=False.
@@ -22,10 +21,11 @@ def Entropy(p, input_var=None, analytical=True):
     >>> import torch
     >>> from pixyz.distributions import Normal
     >>> p = Normal(loc=torch.tensor(0.), scale=torch.tensor(1.), var=["x"], features_shape=[64])
-    >>> loss_cls = Entropy(p)
+    >>> loss_cls = Entropy(p, analytical=True)
     >>> print(loss_cls)
     H \left[ {p(x)} \right]
-    >>> loss = loss_cls.eval()
+    >>> loss_cls.eval()
+    tensor([90.8121])
     >>> loss_cls = Entropy(p, analytical=False)
     >>> print(loss_cls)
     - \mathbb{E}_{p(x)} \left[\log p(x) \right]
@@ -62,9 +62,8 @@ def CrossEntropy(p, q, input_var=None, analytical=False):
 
     .. math::
 
-        H[p||q] = -\mathbb{E}_{p(x)}[\log q(x)] \approx -\frac{1}{L}\sum_{l=1}^L \log q(x_l),
-
-    where :math:`x_l \sim p(x)`.
+        H[p||q] &= -\mathbb{E}_{p(x)}[\log q(x)] \qquad \text{(analytical)}\\
+        &\approx -\frac{1}{L}\sum_{l=1}^L \log q(x_l), \quad \text{where} \quad x_l \sim p(x) \quad \text{(MC approximation)}.
 
     Note:
         This class is a special case of the :attr:`Expectation` class if analytical=False.
@@ -74,14 +73,15 @@ def CrossEntropy(p, q, input_var=None, analytical=False):
     >>> import torch
     >>> from pixyz.distributions import Normal
     >>> p = Normal(loc=torch.tensor(0.), scale=torch.tensor(1.), var=["x"], features_shape=[64], name="p")
-    >>> q = Normal(loc=torch.tensor(0.), scale=torch.tensor(1.), var=["x"], features_shape=[64], name="q")
-    >>> loss_cls = CrossEntropy(p, q)
-    >>> print(loss_cls)
-    - \mathbb{E}_{p(x)} \left[\log q(x) \right]
-    >>> loss = loss_cls.eval()
+    >>> q = Normal(loc=torch.tensor(1.), scale=torch.tensor(1.), var=["x"], features_shape=[64], name="q")
     >>> loss_cls = CrossEntropy(p, q, analytical=True)
     >>> print(loss_cls)
     D_{KL} \left[p(x)||q(x) \right] + H \left[ {p(x)} \right]
+    >>> loss_cls.eval()
+    tensor([122.8121])
+    >>> loss_cls = CrossEntropy(p, q, analytical=False)
+    >>> print(loss_cls)
+    - \mathbb{E}_{p(x)} \left[\log q(x) \right]
     >>> loss = loss_cls.eval()
     """
     if analytical:

--- a/pixyz/losses/entropy.py
+++ b/pixyz/losses/entropy.py
@@ -3,7 +3,7 @@ import sympy
 from .losses import Loss, SetLoss
 
 
-class Entropy(SetLoss):
+class EmpiricalEntropy(SetLoss):
     r"""
     Entropy (Monte Carlo approximation).
 
@@ -21,7 +21,7 @@ class Entropy(SetLoss):
     >>> import torch
     >>> from pixyz.distributions import Normal
     >>> p = Normal(loc=torch.tensor(0.), scale=torch.tensor(1.), var=["x"], features_shape=[64])
-    >>> loss_cls = Entropy(p)
+    >>> loss_cls = EmpiricalEntropy(p)
     >>> print(loss_cls)
     - \mathbb{E}_{p(x)} \left[\log p(x) \right]
     >>> loss = loss_cls.eval()
@@ -35,7 +35,7 @@ class Entropy(SetLoss):
         super().__init__(loss)
 
 
-class AnalyticalEntropy(Loss):
+class Entropy(Loss):
     r"""
     Entropy (analytical).
 
@@ -48,7 +48,7 @@ class AnalyticalEntropy(Loss):
     >>> import torch
     >>> from pixyz.distributions import Normal
     >>> p = Normal(loc=torch.tensor(0.), scale=torch.tensor(1.), var=["x"], features_shape=[64])
-    >>> loss_cls = AnalyticalEntropy(p)
+    >>> loss_cls = Entropy(p)
     >>> print(loss_cls)
     - \mathbb{E}_{p(x)} \left[\log p(x) \right]
     >>> loss = loss_cls.eval()
@@ -69,7 +69,7 @@ class AnalyticalEntropy(Loss):
         return entropy, x_dict
 
 
-class CrossEntropy(SetLoss):
+class EmpiricalCrossEntropy(SetLoss):
     r"""
     Cross entropy, a.k.a., the negative expected value of log-likelihood (Monte Carlo approximation).
 
@@ -88,7 +88,7 @@ class CrossEntropy(SetLoss):
     >>> from pixyz.distributions import Normal
     >>> p = Normal(loc=torch.tensor(0.), scale=torch.tensor(1.), var=["x"], features_shape=[64], name="p")
     >>> q = Normal(loc=torch.tensor(0.), scale=torch.tensor(1.), var=["x"], features_shape=[64], name="q")
-    >>> loss_cls = CrossEntropy(p, q)
+    >>> loss_cls = EmpiricalCrossEntropy(p, q)
     >>> print(loss_cls)
     - \mathbb{E}_{p(x)} \left[\log q(x) \right]
     >>> loss = loss_cls.eval()

--- a/pixyz/losses/entropy.py
+++ b/pixyz/losses/entropy.py
@@ -26,7 +26,8 @@ def Entropy(p, input_var=None, analytical=True):
     >>> loss_cls = Entropy(p, analytical=False)
     >>> print(loss_cls)
     - \mathbb{E}_{p(x)} \left[\log p(x) \right]
-    >>> loss = loss_cls.eval()
+    >>> loss_cls.eval() # doctest: +SKIP
+    tensor([99.1524])
     """
     if analytical:
         loss = AnalyticalEntropy(p, input_var=input_var)
@@ -76,7 +77,8 @@ def CrossEntropy(p, q, input_var=None, analytical=False):
     >>> loss_cls = CrossEntropy(p, q, analytical=False)
     >>> print(loss_cls)
     - \mathbb{E}_{p(x)} \left[\log q(x) \right]
-    >>> loss = loss_cls.eval()
+    >>> loss_cls.eval() # doctest: +SKIP
+    tensor([127.1449])
     """
     if analytical:
         loss = Entropy(p) + KullbackLeibler(p, q)

--- a/pixyz/losses/losses.py
+++ b/pixyz/losses/losses.py
@@ -588,8 +588,7 @@ class Expectation(Loss):
     .. math::
 
         \mathbb{E}_{p(x)}[f(x)] \approx \frac{1}{L}\sum_{l=1}^L f(x_l),
-
-    where :math:`x_l \sim p(x)`.
+         \quad \text{where}\quad x_l \sim p(x).
 
     Note that :math:`f` doesn't need to be able to sample, which is known as the law of the unconscious statistician
     (LOTUS).

--- a/pixyz/losses/losses.py
+++ b/pixyz/losses/losses.py
@@ -581,22 +581,6 @@ class BatchSum(LossSelfOperator):
         return loss.sum(), x_dict
 
 
-class SetLoss(Loss):
-    def __init__(self, loss):
-        self.loss = loss
-        self._input_var = loss.input_var
-
-    def __getattr__(self, name):
-        getattr(self.loss, name)
-
-    def _get_eval(self, x_dict, **kwargs):
-        return self.loss._get_eval(x_dict, **kwargs)
-
-    @property
-    def _symbol(self):
-        return self.loss._symbol
-
-
 class Expectation(Loss):
     r"""
     Expectation of a given function (Monte Carlo approximation).


### PR DESCRIPTION
- Implemented Empirical KL Loss using `SetLoss`.
- Renamed below
  - "AnalyticalEntropy" to "Entropy"
  - "Entropy" to "EmpiricalEntropy"
  - "CrossEntropy" to "EmpiricalCrossEntropy"