### PR TITLE
Fix temperature parameter of Relaxed Distribution can be moved to GPU

### DIFF
--- a/pixyz/distributions/distributions.py
+++ b/pixyz/distributions/distributions.py
@@ -675,13 +675,11 @@ class DistributionBase(Distribution):
         raise ValueError("the shape of a given parameter {} and features_shape {} "
                          "do not match.".format(features.size(), self.features_shape))
 
-    @property
-    def params_keys(self):
+    def get_params_keys(self, **kwargs):
         """list: Return the list of parameter names for this distribution."""
         raise NotImplementedError()
 
-    @property
-    def distribution_torch_class(self):
+    def get_distribution_torch_class(self, **kwargs):
         """Return the class of PyTorch distribution."""
         raise NotImplementedError()
 
@@ -690,16 +688,16 @@ class DistributionBase(Distribution):
         """Return the instance of PyTorch distribution."""
         return self._dist
 
-    def set_dist(self, x_dict={}, sampling=False, batch_n=None, **kwargs):
+    def set_dist(self, x_dict={}, relaxing=False, batch_n=None, **kwargs):
         """Set :attr:`dist` as PyTorch distributions given parameters.
 
-        This requires that :attr:`params_keys` and :attr:`distribution_torch_class` are set.
+        This requires that :attr:`get_params_keys` and :attr:`get_distribution_torch_class` are set.
 
         Parameters
         ----------
         x_dict : :obj:`dict`, defaults to {}.
             Parameters of this distribution.
-        sampling : :obj:`bool`, defaults to False.
+        relaxing : :obj:`bool`, defaults to False.
             Choose whether to use relaxed_* in PyTorch distribution.
         batch_n : :obj:`int`, defaults to None.
             Set batch size of parameters.
@@ -710,11 +708,11 @@ class DistributionBase(Distribution):
         -------
 
         """
-        params = self.get_params(x_dict, **kwargs)
-        if set(self.params_keys) != set(params.keys()):
+        params = self.get_params(x_dict, relaxing=relaxing, **kwargs)
+        if set(self.get_params_keys(relaxing=relaxing, **kwargs)) != set(params.keys()):
             raise ValueError()
 
-        self._dist = self.distribution_torch_class(**params)
+        self._dist = self.get_distribution_torch_class(relaxing=relaxing, **kwargs)(**params)
 
         # expand batch_n
         if batch_n:
@@ -756,7 +754,7 @@ class DistributionBase(Distribution):
 
     def get_log_prob(self, x_dict, sum_features=True, feature_dims=None):
         _x_dict = get_dict_values(x_dict, self._cond_var, return_dict=True)
-        self.set_dist(_x_dict, sampling=False)
+        self.set_dist(_x_dict, relaxing=False)
 
         x_targets = get_dict_values(x_dict, self._var)
         log_prob = self.dist.log_prob(*x_targets)
@@ -765,21 +763,22 @@ class DistributionBase(Distribution):
 
         return log_prob
 
-    def get_params(self, params_dict={}):
+    def get_params(self, params_dict={}, **kwargs):
         params_dict, vars_dict = replace_dict_keys_split(params_dict, self.replace_params_dict)
         output_dict = self.forward(**vars_dict)
 
         output_dict.update(params_dict)
 
         # append constant parameters to output_dict
-        constant_params_dict = get_dict_values(dict(self.named_buffers()), self.params_keys, return_dict=True)
+        constant_params_dict = get_dict_values(dict(self.named_buffers()), self.get_params_keys(**kwargs),
+                                               return_dict=True)
         output_dict.update(constant_params_dict)
 
         return output_dict
 
     def get_entropy(self, x_dict={}, sum_features=True, feature_dims=None):
         _x_dict = get_dict_values(x_dict, self._cond_var, return_dict=True)
-        self.set_dist(_x_dict, sampling=False)
+        self.set_dist(_x_dict, relaxing=False)
 
         entropy = self.dist.entropy()
         if sum_features:
@@ -1068,7 +1067,7 @@ class ReplaceVarDistribution(Distribution):
 
     def set_dist(self, x_dict={}, sampling=False, batch_n=None, **kwargs):
         x_dict = replace_dict_keys(x_dict, self._replace_inv_cond_var_dict)
-        return self.p.set_dist(x_dict=x_dict, sampling=sampling, batch_n=batch_n, **kwargs)
+        return self.p.set_dist(x_dict=x_dict, relaxing=sampling, batch_n=batch_n, **kwargs)
 
     def sample(self, x_dict={}, batch_n=None, sample_shape=torch.Size(), return_all=True, reparam=False, **kwargs):
         input_dict = get_dict_values(x_dict, self.cond_var, return_dict=True)

--- a/pixyz/distributions/exponential_distributions.py
+++ b/pixyz/distributions/exponential_distributions.py
@@ -51,7 +51,7 @@ class Bernoulli(DistributionBase):
 
 
 class RelaxedBernoulli(Bernoulli):
-    """Relaxed (re-parameterizable) Bernoulli distribution parameterized by :attr:`probs`."""
+    """Relaxed (re-parameterizable) Bernoulli distribution parameterized by :attr:`probs` and :attr:`temperature`."""
     def __init__(self, cond_var=[], var=["x"], name="p", features_shape=torch.Size(), temperature=torch.tensor(0.1),
                  probs=None):
         super(Bernoulli, self).__init__(cond_var, var, name, features_shape, **_valid_param_dict({
@@ -128,7 +128,10 @@ class Categorical(DistributionBase):
 
 
 class RelaxedCategorical(Categorical):
-    """Relaxed (re-parameterizable) categorical distribution parameterized by :attr:`probs`."""
+    """
+    Relaxed (re-parameterizable) categorical distribution parameterized by :attr:`probs` and :attr:`temperature`.
+    Notes: a shape of temperature should contain the event shape of this Categorical distribution.
+    """
     def __init__(self, cond_var=[], var=["x"], name="p", features_shape=torch.Size(), temperature=torch.tensor(0.1),
                  probs=None):
         super(Categorical, self).__init__(cond_var, var, name, features_shape,

--- a/pixyz/distributions/exponential_distributions.py
+++ b/pixyz/distributions/exponential_distributions.py
@@ -23,12 +23,10 @@ class Normal(DistributionBase):
     def __init__(self, cond_var=[], var=['x'], name='p', features_shape=torch.Size(), loc=None, scale=None):
         super().__init__(cond_var, var, name, features_shape, **_valid_param_dict({'loc': loc, 'scale': scale}))
 
-    @property
-    def params_keys(self):
+    def get_params_keys(self, **kwargs):
         return ["loc", "scale"]
 
-    @property
-    def distribution_torch_class(self):
+    def get_distribution_torch_class(self, **kwargs):
         return NormalTorch
 
     @property
@@ -41,12 +39,10 @@ class Bernoulli(DistributionBase):
     def __init__(self, cond_var=[], var=['x'], name='p', features_shape=torch.Size(), probs=None):
         super().__init__(cond_var, var, name, features_shape, **_valid_param_dict({'probs': probs}))
 
-    @property
-    def params_keys(self):
+    def get_params_keys(self, **kwargs):
         return ["probs"]
 
-    @property
-    def distribution_torch_class(self):
+    def get_distribution_torch_class(self, **kwargs):
         return BernoulliTorch
 
     @property
@@ -56,46 +52,38 @@ class Bernoulli(DistributionBase):
 
 class RelaxedBernoulli(Bernoulli):
     """Relaxed (re-parameterizable) Bernoulli distribution parameterized by :attr:`probs`."""
-
     def __init__(self, cond_var=[], var=["x"], name="p", features_shape=torch.Size(), temperature=torch.tensor(0.1),
                  probs=None):
-        self._temperature = temperature
+        super(Bernoulli, self).__init__(cond_var, var, name, features_shape, **_valid_param_dict({
+            'probs': probs, 'temperature': temperature}))
 
-        super().__init__(cond_var=cond_var, var=var, name=name, features_shape=features_shape, probs=probs)
+    def get_params_keys(self, relaxing=True, **kwargs):
+        if relaxing:
+            return ["probs", "temperature"]
+        else:
+            return ["probs"]
 
-    @property
-    def temperature(self):
-        return self._temperature
-
-    @property
-    def distribution_torch_class(self):
-        return BernoulliTorch
-
-    @property
-    def relaxed_distribution_torch_class(self):
+    def get_distribution_torch_class(self, relaxing=True, **kwargs):
         """Use relaxed version only when sampling"""
-        return RelaxedBernoulliTorch
+        if relaxing:
+            return RelaxedBernoulliTorch
+        else:
+            return BernoulliTorch
 
     @property
     def distribution_name(self):
         return "RelaxedBernoulli"
 
-    def set_dist(self, x_dict={}, sampling=True, batch_n=None, **kwargs):
-        params = self.get_params(x_dict)
-        if sampling is True:
-            self._dist = self.relaxed_distribution_torch_class(temperature=self.temperature, **params)
-        else:
-            self._dist = self.distribution_torch_class(**params)
+    def set_dist(self, x_dict={}, relaxing=True, batch_n=None, **kwargs):
+        super().set_dist(x_dict, relaxing, batch_n, **kwargs)
 
-        # expand batch_n
-        if batch_n:
-            batch_shape = self._dist.batch_shape
-            if batch_shape[0] == 1:
-                self._dist = self._dist.expand(torch.Size([batch_n]) + batch_shape[1:])
-            elif batch_shape[0] == batch_n:
-                return
-            else:
-                raise ValueError()
+    def sample_mean(self, x_dict={}):
+        self.set_dist(x_dict, relaxing=False)
+        return self.dist.mean
+
+    def sample_variance(self, x_dict={}):
+        self.set_dist(x_dict, relaxing=False)
+        return self.dist.variance
 
 
 class FactorizedBernoulli(Bernoulli):
@@ -128,12 +116,10 @@ class Categorical(DistributionBase):
         super().__init__(cond_var=cond_var, var=var, name=name, features_shape=features_shape,
                          **_valid_param_dict({'probs': probs}))
 
-    @property
-    def params_keys(self):
+    def get_params_keys(self, **kwargs):
         return ["probs"]
 
-    @property
-    def distribution_torch_class(self):
+    def get_distribution_torch_class(self, **kwargs):
         return CategoricalTorch
 
     @property
@@ -143,53 +129,37 @@ class Categorical(DistributionBase):
 
 class RelaxedCategorical(Categorical):
     """Relaxed (re-parameterizable) categorical distribution parameterized by :attr:`probs`."""
-
     def __init__(self, cond_var=[], var=["x"], name="p", features_shape=torch.Size(), temperature=torch.tensor(0.1),
                  probs=None):
-        self._temperature = temperature
+        super(Categorical, self).__init__(cond_var, var, name, features_shape,
+                                          **_valid_param_dict({'probs': probs, 'temperature': temperature}))
 
-        super().__init__(cond_var=cond_var, var=var, name=name, features_shape=features_shape, probs=probs)
+    def get_params_keys(self, relaxing=True, **kwargs):
+        if relaxing:
+            return ['probs', 'temperature']
+        else:
+            return ['probs']
 
-    @property
-    def temperature(self):
-        return self._temperature
-
-    @property
-    def distribution_torch_class(self):
-        return CategoricalTorch
-
-    @property
-    def relaxed_distribution_torch_class(self):
+    def get_distribution_torch_class(self, relaxing=True, **kwargs):
         """Use relaxed version only when sampling"""
-        return RelaxedOneHotCategoricalTorch
+        if relaxing:
+            return RelaxedOneHotCategoricalTorch
+        else:
+            return CategoricalTorch
 
     @property
     def distribution_name(self):
         return "RelaxedCategorical"
 
-    def set_dist(self, x_dict={}, sampling=True, batch_n=None, **kwargs):
-        params = self.get_params(x_dict)
-        if sampling is True:
-            self._dist = self.relaxed_distribution_torch_class(temperature=self.temperature, **params)
-        else:
-            self._dist = self.distribution_torch_class(**params)
-
-        # expand batch_n
-        if batch_n:
-            batch_shape = self._dist.batch_shape
-            if batch_shape[0] == 1:
-                self._dist = self._dist.expand(torch.Size([batch_n]) + batch_shape[1:])
-            elif batch_shape[0] == batch_n:
-                return
-            else:
-                raise ValueError()
+    def set_dist(self, x_dict={}, relaxing=True, batch_n=None, **kwargs):
+        super().set_dist(x_dict, relaxing, batch_n, **kwargs)
 
     def sample_mean(self, x_dict={}):
-        self.set_dist(x_dict, sampling=False)
+        self.set_dist(x_dict, relaxing=False)
         return self.dist.mean
 
     def sample_variance(self, x_dict={}):
-        self.set_dist(x_dict, sampling=False)
+        self.set_dist(x_dict, relaxing=False)
         return self.dist.variance
 
 
@@ -206,12 +176,10 @@ class Multinomial(DistributionBase):
     def total_count(self):
         return self._total_count
 
-    @property
-    def params_keys(self):
+    def get_params_keys(self, **kwargs):
         return ["probs"]
 
-    @property
-    def distribution_torch_class(self):
+    def get_distribution_torch_class(self, **kwargs):
         return MultinomialTorch
 
     @property
@@ -225,12 +193,10 @@ class Dirichlet(DistributionBase):
         super().__init__(cond_var=cond_var, var=var, name=name, features_shape=features_shape,
                          **_valid_param_dict({'concentration': concentration}))
 
-    @property
-    def params_keys(self):
+    def get_params_keys(self, **kwargs):
         return ["concentration"]
 
-    @property
-    def distribution_torch_class(self):
+    def get_distribution_torch_class(self, kwargs):
         return DirichletTorch
 
     @property
@@ -245,12 +211,10 @@ class Beta(DistributionBase):
         super().__init__(cond_var=cond_var, var=var, name=name, features_shape=features_shape,
                          **_valid_param_dict({'concentration1': concentration1, 'concentration0': concentration0}))
 
-    @property
-    def params_keys(self):
+    def get_params_keys(self, **kwargs):
         return ["concentration1", "concentration0"]
 
-    @property
-    def distribution_torch_class(self):
+    def get_distribution_torch_class(self, **kwargs):
         return BetaTorch
 
     @property
@@ -266,12 +230,10 @@ class Laplace(DistributionBase):
         super().__init__(cond_var=cond_var, var=var, name=name, features_shape=features_shape,
                          **_valid_param_dict({'loc': loc, 'scale': scale}))
 
-    @property
-    def params_keys(self):
+    def get_params_keys(self, **kwargs):
         return ["loc", "scale"]
 
-    @property
-    def distribution_torch_class(self):
+    def get_distribution_torch_class(self, **kwargs):
         return LaplaceTorch
 
     @property
@@ -287,12 +249,10 @@ class Gamma(DistributionBase):
         super().__init__(cond_var=cond_var, var=var, name=name, features_shape=features_shape,
                          **_valid_param_dict({'concentration': concentration, 'rate': rate}))
 
-    @property
-    def params_keys(self):
+    def get_params_keys(self, **kwargs):
         return ["concentration", "rate"]
 
-    @property
-    def distribution_torch_class(self):
+    def get_distribution_torch_class(self, **kwargs):
         return GammaTorch
 
     @property

--- a/pixyz/losses/divergences.py
+++ b/pixyz/losses/divergences.py
@@ -53,7 +53,7 @@ class AnalyticalKullbackLeibler(Loss):
         return sympy.Symbol("D_{{KL}} \\left[{}||{} \\right]".format(self.p.prob_text, self.q.prob_text))
 
     def _get_eval(self, x_dict, **kwargs):
-        if (not hasattr(self.p, 'distribution_torch_class')) or (not hasattr(self.q, 'distribution_torch_class')):
+        if (not hasattr(self.p, 'get_distribution_torch_class')) or (not hasattr(self.q, 'get_distribution_torch_class')):
             raise ValueError("Divergence between these two distributions cannot be evaluated, "
                              "got %s and %s." % (self.p.distribution_name, self.q.distribution_name))
 

--- a/pixyz/losses/entropy.py
+++ b/pixyz/losses/entropy.py
@@ -46,7 +46,7 @@ class AnalyticalEntropy(Loss):
         return sympy.Symbol(f"H \\left[ {p_text} \\right]")
 
     def _get_eval(self, x_dict, **kwargs):
-        if not hasattr(self.p, 'distribution_torch_class'):
+        if not hasattr(self.p, 'get_distribution_torch_class'):
             raise ValueError("Entropy of this distribution cannot be evaluated, "
                              "got %s." % self.p.distribution_name)
 


### PR DESCRIPTION
To treat temperature parameter of Relaxed Distribution as a normal variable, I modified some basic class.
- `DistributionBase.distribution_torch_class` property -> `get_distribution_torch_class(self, relaxing, **kwargs)`
- `DistributionBase.param_keys` property -> `get_param_keys(self, relaxing, **kwargs)`
- rename `sampling` option of DistributionAPI as `relaxing`