### PR TITLE
Fix #101

### DIFF
--- a/pixyz/losses/iteration.py
+++ b/pixyz/losses/iteration.py
@@ -121,6 +121,8 @@ class IterativeLoss(Loss):
 
     def _get_eval(self, x_dict, **kwargs):
         series_x_dict = get_dict_values(x_dict, self.series_var, return_dict=True)
+        updated_x_dict = get_dict_values(x_dict, list(self.update_value.values()), return_dict=True)
+
         step_loss_sum = 0
 
         # set max_iter
@@ -154,5 +156,8 @@ class IterativeLoss(Loss):
 
         loss = step_loss_sum
 
+        # Restore original values
         x_dict.update(series_x_dict)
+        x_dict.update(updated_x_dict)
+        
         return loss, x_dict


### PR DESCRIPTION
Fix #101 
The reason for this bug is that some given input values (which correspond to values of the "update_value" dictionary) are overwritten after executing the evaluation on IterativeLoss.