### PR TITLE
remove relaxing option

### DIFF
--- a/pixyz/distributions/distributions.py
+++ b/pixyz/distributions/distributions.py
@@ -679,11 +679,13 @@ class DistributionBase(Distribution):
         raise ValueError("the shape of a given parameter {} and features_shape {} "
                          "do not match.".format(features.size(), self.features_shape))
 
-    def get_params_keys(self, **kwargs):
+    @property
+    def params_keys(self):
         """list: Return the list of parameter names for this distribution."""
         raise NotImplementedError()
 
-    def get_distribution_torch_class(self, **kwargs):
+    @property
+    def distribution_torch_class(self):
         """Return the class of PyTorch distribution."""
         raise NotImplementedError()
 
@@ -695,7 +697,7 @@ class DistributionBase(Distribution):
     def set_dist(self, x_dict={}, batch_n=None, **kwargs):
         """Set :attr:`dist` as PyTorch distributions given parameters.
 
-        This requires that :attr:`get_params_keys` and :attr:`get_distribution_torch_class` are set.
+        This requires that :attr:`params_keys` and :attr:`distribution_torch_class` are set.
 
         Parameters
         ----------
@@ -711,10 +713,10 @@ class DistributionBase(Distribution):
 
         """
         params = self.get_params(x_dict, **kwargs)
-        if set(self.get_params_keys(**kwargs)) != set(params.keys()):
+        if set(self.params_keys) != set(params.keys()):
             raise ValueError()
 
-        self._dist = self.get_distribution_torch_class(**kwargs)(**params)
+        self._dist = self.distribution_torch_class(**params)
 
         # expand batch_n
         if batch_n:
@@ -773,7 +775,7 @@ class DistributionBase(Distribution):
         output_dict.update(params_dict)
 
         # append constant parameters to output_dict
-        constant_params_dict = get_dict_values(dict(self.named_buffers()), self.get_params_keys(**kwargs),
+        constant_params_dict = get_dict_values(dict(self.named_buffers()), self.params_keys,
                                                return_dict=True)
         output_dict.update(constant_params_dict)
 

--- a/pixyz/distributions/distributions.py
+++ b/pixyz/distributions/distributions.py
@@ -656,9 +656,8 @@ class DistributionBase(Distribution):
                 if params_dict[key] in self._cond_var:
                     self.replace_params_dict[params_dict[key]] = key
                 else:
-                    raise ValueError("parameter setting {}:{} is not valid"
-                                     " because cond_var does not contains {}.".format(
-                        key, params_dict[key], params_dict[key]))
+                    raise ValueError("parameter setting {}:{} is not valid because cond_var does not contains {}."
+                                     .format(key, params_dict[key], params_dict[key]))
             elif isinstance(params_dict[key], torch.Tensor):
                 features = params_dict[key]
                 features_checked = self._check_features_shape(features)

--- a/pixyz/distributions/exponential_distributions.py
+++ b/pixyz/distributions/exponential_distributions.py
@@ -65,33 +65,25 @@ class RelaxedBernoulli(Bernoulli):
         super(Bernoulli, self).__init__(cond_var, var, name, features_shape, **_valid_param_dict({
             'probs': probs, 'temperature': temperature}))
 
-    def get_params_keys(self, relaxing=True, **kwargs):
-        if relaxing:
-            return ["probs", "temperature"]
-        else:
-            return ["probs"]
+    def get_params_keys(self, **kwargs):
+        return ["probs", "temperature"]
 
-    def get_distribution_torch_class(self, relaxing=True, **kwargs):
+    def get_distribution_torch_class(self, **kwargs):
         """Use relaxed version only when sampling"""
-        if relaxing:
-            return RelaxedBernoulliTorch
-        else:
-            return BernoulliTorch
+        return RelaxedBernoulliTorch
 
     @property
     def distribution_name(self):
         return "RelaxedBernoulli"
 
-    def set_dist(self, x_dict={}, relaxing=True, batch_n=None, **kwargs):
-        super().set_dist(x_dict, relaxing, batch_n, **kwargs)
+    def get_entropy(self, x_dict={}, sum_features=True, feature_dims=None):
+        raise NotImplementedError()
 
     def sample_mean(self, x_dict={}):
-        self.set_dist(x_dict, relaxing=False)
-        return self.dist.mean
+        raise NotImplementedError()
 
     def sample_variance(self, x_dict={}):
-        self.set_dist(x_dict, relaxing=False)
-        return self.dist.variance
+        raise NotImplementedError()
 
     @property
     def has_reparam(self):
@@ -153,33 +145,25 @@ class RelaxedCategorical(Categorical):
         super(Categorical, self).__init__(cond_var, var, name, features_shape,
                                           **_valid_param_dict({'probs': probs, 'temperature': temperature}))
 
-    def get_params_keys(self, relaxing=True, **kwargs):
-        if relaxing:
-            return ['probs', 'temperature']
-        else:
-            return ['probs']
+    def get_params_keys(self, **kwargs):
+        return ['probs', 'temperature']
 
-    def get_distribution_torch_class(self, relaxing=True, **kwargs):
+    def get_distribution_torch_class(self, **kwargs):
         """Use relaxed version only when sampling"""
-        if relaxing:
-            return RelaxedOneHotCategoricalTorch
-        else:
-            return CategoricalTorch
+        return RelaxedOneHotCategoricalTorch
 
     @property
     def distribution_name(self):
         return "RelaxedCategorical"
 
-    def set_dist(self, x_dict={}, relaxing=True, batch_n=None, **kwargs):
-        super().set_dist(x_dict, relaxing, batch_n, **kwargs)
+    def get_entropy(self, x_dict={}, sum_features=True, feature_dims=None):
+        raise NotImplementedError()
 
     def sample_mean(self, x_dict={}):
-        self.set_dist(x_dict, relaxing=False)
-        return self.dist.mean
+        raise NotImplementedError()
 
     def sample_variance(self, x_dict={}):
-        self.set_dist(x_dict, relaxing=False)
-        return self.dist.variance
+        raise NotImplementedError()
 
     @property
     def has_reparam(self):

--- a/pixyz/distributions/exponential_distributions.py
+++ b/pixyz/distributions/exponential_distributions.py
@@ -23,10 +23,12 @@ class Normal(DistributionBase):
     def __init__(self, cond_var=[], var=['x'], name='p', features_shape=torch.Size(), loc=None, scale=None):
         super().__init__(cond_var, var, name, features_shape, **_valid_param_dict({'loc': loc, 'scale': scale}))
 
-    def get_params_keys(self, **kwargs):
+    @property
+    def params_keys(self):
         return ["loc", "scale"]
 
-    def get_distribution_torch_class(self, **kwargs):
+    @property
+    def distribution_torch_class(self):
         return NormalTorch
 
     @property
@@ -43,10 +45,12 @@ class Bernoulli(DistributionBase):
     def __init__(self, cond_var=[], var=['x'], name='p', features_shape=torch.Size(), probs=None):
         super().__init__(cond_var, var, name, features_shape, **_valid_param_dict({'probs': probs}))
 
-    def get_params_keys(self, **kwargs):
+    @property
+    def params_keys(self):
         return ["probs"]
 
-    def get_distribution_torch_class(self, **kwargs):
+    @property
+    def distribution_torch_class(self):
         return BernoulliTorch
 
     @property
@@ -65,10 +69,12 @@ class RelaxedBernoulli(Bernoulli):
         super(Bernoulli, self).__init__(cond_var, var, name, features_shape, **_valid_param_dict({
             'probs': probs, 'temperature': temperature}))
 
-    def get_params_keys(self, **kwargs):
+    @property
+    def params_keys(self):
         return ["probs", "temperature"]
 
-    def get_distribution_torch_class(self, **kwargs):
+    @property
+    def distribution_torch_class(self):
         """Use relaxed version only when sampling"""
         return RelaxedBernoulliTorch
 
@@ -120,10 +126,12 @@ class Categorical(DistributionBase):
         super().__init__(cond_var=cond_var, var=var, name=name, features_shape=features_shape,
                          **_valid_param_dict({'probs': probs}))
 
-    def get_params_keys(self, **kwargs):
+    @property
+    def params_keys(self):
         return ["probs"]
 
-    def get_distribution_torch_class(self, **kwargs):
+    @property
+    def distribution_torch_class(self):
         return CategoricalTorch
 
     @property
@@ -145,10 +153,12 @@ class RelaxedCategorical(Categorical):
         super(Categorical, self).__init__(cond_var, var, name, features_shape,
                                           **_valid_param_dict({'probs': probs, 'temperature': temperature}))
 
-    def get_params_keys(self, **kwargs):
+    @property
+    def params_keys(self):
         return ['probs', 'temperature']
 
-    def get_distribution_torch_class(self, **kwargs):
+    @property
+    def distribution_torch_class(self):
         """Use relaxed version only when sampling"""
         return RelaxedOneHotCategoricalTorch
 
@@ -183,10 +193,12 @@ class Multinomial(DistributionBase):
     def total_count(self):
         return self._total_count
 
-    def get_params_keys(self, **kwargs):
+    @property
+    def params_keys(self):
         return ["probs"]
 
-    def get_distribution_torch_class(self, **kwargs):
+    @property
+    def distribution_torch_class(self):
         return MultinomialTorch
 
     @property
@@ -204,10 +216,12 @@ class Dirichlet(DistributionBase):
         super().__init__(cond_var=cond_var, var=var, name=name, features_shape=features_shape,
                          **_valid_param_dict({'concentration': concentration}))
 
-    def get_params_keys(self, **kwargs):
+    @property
+    def params_keys(self):
         return ["concentration"]
 
-    def get_distribution_torch_class(self, kwargs):
+    @property
+    def distribution_torch_class(self):
         return DirichletTorch
 
     @property
@@ -226,10 +240,12 @@ class Beta(DistributionBase):
         super().__init__(cond_var=cond_var, var=var, name=name, features_shape=features_shape,
                          **_valid_param_dict({'concentration1': concentration1, 'concentration0': concentration0}))
 
-    def get_params_keys(self, **kwargs):
+    @property
+    def params_keys(self):
         return ["concentration1", "concentration0"]
 
-    def get_distribution_torch_class(self, **kwargs):
+    @property
+    def distribution_torch_class(self):
         return BetaTorch
 
     @property
@@ -249,10 +265,12 @@ class Laplace(DistributionBase):
         super().__init__(cond_var=cond_var, var=var, name=name, features_shape=features_shape,
                          **_valid_param_dict({'loc': loc, 'scale': scale}))
 
-    def get_params_keys(self, **kwargs):
+    @property
+    def params_keys(self):
         return ["loc", "scale"]
 
-    def get_distribution_torch_class(self, **kwargs):
+    @property
+    def distribution_torch_class(self):
         return LaplaceTorch
 
     @property
@@ -272,10 +290,12 @@ class Gamma(DistributionBase):
         super().__init__(cond_var=cond_var, var=var, name=name, features_shape=features_shape,
                          **_valid_param_dict({'concentration': concentration, 'rate': rate}))
 
-    def get_params_keys(self, **kwargs):
+    @property
+    def params_keys(self):
         return ["concentration", "rate"]
 
-    def get_distribution_torch_class(self, **kwargs):
+    @property
+    def distribution_torch_class(self):
         return GammaTorch
 
     @property

--- a/pixyz/losses/divergences.py
+++ b/pixyz/losses/divergences.py
@@ -53,7 +53,7 @@ class AnalyticalKullbackLeibler(Divergence):
         return sympy.Symbol("D_{{KL}} \\left[{}||{} \\right]".format(self.p.prob_text, self.q.prob_text))
 
     def forward(self, x_dict, **kwargs):
-        if (not hasattr(self.p, 'get_distribution_torch_class')) or (not hasattr(self.q, 'get_distribution_torch_class')):
+        if (not hasattr(self.p, 'distribution_torch_class')) or (not hasattr(self.q, 'distribution_torch_class')):
             raise ValueError("Divergence between these two distributions cannot be evaluated, "
                              "got %s and %s." % (self.p.distribution_name, self.q.distribution_name))
 

--- a/pixyz/losses/entropy.py
+++ b/pixyz/losses/entropy.py
@@ -54,7 +54,7 @@ class AnalyticalEntropy(Loss):
         return sympy.Symbol(f"H \\left[ {p_text} \\right]")
 
     def forward(self, x_dict, **kwargs):
-        if not hasattr(self.p, 'get_distribution_torch_class'):
+        if not hasattr(self.p, 'distribution_torch_class'):
             raise ValueError("Entropy of this distribution cannot be evaluated, "
                              "got %s." % self.p.distribution_name)
 

--- a/pixyz/losses/losses.py
+++ b/pixyz/losses/losses.py
@@ -821,7 +821,7 @@ class DataParalleledLoss(Loss):
     >>> from torch import optim
     >>> from torch.nn import functional as F
     >>> from pixyz.distributions import Bernoulli, Normal
-    >>> from pixyz.losses import StochasticReconstructionLoss, KullbackLeibler, DataParalleledLoss
+    >>> from pixyz.losses import KullbackLeibler, DataParalleledLoss
     >>> from pixyz.models import Model
     >>> used_gpu_i = set()
     >>> used_gpu_g = set()
@@ -846,7 +846,7 @@ class DataParalleledLoss(Loss):
     >>> prior = Normal(loc=torch.tensor(0.), scale=torch.tensor(1.),
     ...                var=["z"], features_shape=[64], name="p_{prior}")
     >>> # Define a loss function (Loss API)
-    >>> reconst = StochasticReconstructionLoss(q, p)
+    >>> reconst = -p.log_prob().expectation(q)
     >>> kl = KullbackLeibler(q, prior)
     >>> batch_loss_cls = (reconst - kl)
     >>> # device settings


### PR DESCRIPTION
## 動機
具象クラス`RelaxedBernoulli`のためのオプション`relaxing`は抽象クラスで指定されていました．
このためDistributionBaseクラスの変更次第で，`RelaxedBernoulli`以外の具象クラスでも不明なオプションを管理する必要が生じる場面があり問題だったため，relaxingオプションを削除し，`RelaxedBernoulli`を単一のモードで動作させることにしました．

## 変更点
- `RelaxedBernoulli`と`RelaxedCategorical`のメソッド引数から`relaxing`オプションを削除
- `DistributionBase`から`relaxing`オプションのデフォルト値指定を削除