### PR TITLE
hot-fix of methods of RelaxedDistribution as reparameterization trick

### DIFF
--- a/pixyz/distributions/distributions.py
+++ b/pixyz/distributions/distributions.py
@@ -4,7 +4,7 @@ import re
 from torch import nn
 from copy import deepcopy
 
-from ..utils import get_dict_values, replace_dict_keys, replace_dict_keys_split, delete_dict_values,\
+from ..utils import get_dict_values, replace_dict_keys, replace_dict_keys_split, delete_dict_values, \
     tolist, sum_samples, convert_latex_name
 from ..losses import LogProb, Prob
 
@@ -990,7 +990,8 @@ class MultiplyDistribution(Distribution):
             return parent_log_prob + child_log_prob
 
         raise ValueError("Two PDFs, {} and {}, have different sizes,"
-                         " so you must modify these tensor sizes.".format(self._parent.prob_text, self._child.prob_text))
+                         " so you must modify these tensor sizes.".format(self._parent.prob_text,
+                                                                          self._child.prob_text))
 
     def __repr__(self):
         return self._parent.__repr__() + "\n" + self._child.__repr__()
@@ -1186,10 +1187,10 @@ class MarginalizeVarDistribution(Distribution):
         _var = deepcopy(p.var)
         _cond_var = deepcopy(p.cond_var)
 
-        if not((set(marginalize_list)) < set(_var)):
+        if not ((set(marginalize_list)) < set(_var)):
             raise ValueError("marginalize_list has unknown variables or it has all of variables of `p`.")
 
-        if not((set(marginalize_list)).isdisjoint(set(_cond_var))):
+        if not ((set(marginalize_list)).isdisjoint(set(_cond_var))):
             raise ValueError("Conditional variables can not be marginalized.")
 
         if len(marginalize_list) == 0:


### PR DESCRIPTION
以前の修正 #94 #108 でRelaxedBernoulliとRelaxedCategoricalの使用に問題が発生していたことが判明しました．

- RelaxedDistribution.get_log_probにおいてrelaxされた後の計算式が用いられるため，1 hot ベクトルなどのハードな値に対してNaNを返してしまう．
- 以前まで定義されていたsample_mean, sample_variance, get_entropyが未定義になる．

これらの挙動を以前と同様に戻しつつ，インターフェースなどの変更を小さく抑えるため，RelaxedDistribution.set_distをオーバーライドすることを提案します．

set_distの実装はDistributionBase, RelaxedBernoulli, RelaxedCategoricalで重複を含むので，より良い実装方法を検討中です．