### PR TITLE
Clone all params of distribution to fix a bug

### DIFF
--- a/pixyz/distributions/distributions.py
+++ b/pixyz/distributions/distributions.py
@@ -647,6 +647,21 @@ class DistributionBase(Distribution):
             these parameters are set as `variables`, the correspondences between these values and the true name of
             these parameters are stored as :obj:`dict` (:attr:`replace_params_dict`).
 
+        Examples
+        --------
+        >>> # This is not an example of _set_buffers. It's just a test. It will be deleted.
+        >>> from os.path import join as pjoin
+        >>> from pixyz.distributions import Normal
+        >>> tmpdir = '.'
+        >>> no_contiguous_tensor = torch.zeros(2, 3).T
+        >>> ones = torch.ones_like(no_contiguous_tensor)
+        >>> p = Normal(loc=no_contiguous_tensor, scale=ones)
+        >>> save_path = pjoin(tmpdir, "tmp.pt")
+        >>> torch.save(p.state_dict(), save_path)
+        >>> # it needs copy of tensor
+        >>> q = Normal(loc=ones, scale=ones)
+        >>> _ = q.load_state_dict(torch.load(save_path))
+        >>> assert torch.all(no_contiguous_tensor == q.loc).item()
         """
 
         self.replace_params_dict = {}
@@ -661,7 +676,8 @@ class DistributionBase(Distribution):
             elif isinstance(params_dict[key], torch.Tensor):
                 features = params_dict[key]
                 features_checked = self._check_features_shape(features)
-                self.register_buffer(key, features_checked)
+                # clone features to make it contiguous & to make it independent.
+                self.register_buffer(key, features_checked.clone())
             else:
                 raise ValueError()
 
@@ -672,9 +688,6 @@ class DistributionBase(Distribution):
 
         if self.features_shape == torch.Size():
             self._features_shape = features.shape
-
-        if not features.is_contiguous():
-            features = features.contiguous()
 
         if features.size() == self.features_shape:
             batches = features.unsqueeze(0)

--- a/pixyz/distributions/distributions.py
+++ b/pixyz/distributions/distributions.py
@@ -646,22 +646,6 @@ class DistributionBase(Distribution):
             If the values of these dictionaries contain parameters which are named as strings, which means that
             these parameters are set as `variables`, the correspondences between these values and the true name of
             these parameters are stored as :obj:`dict` (:attr:`replace_params_dict`).
-
-        Examples
-        --------
-        >>> # This is not an example of _set_buffers. It's just a test. It will be deleted.
-        >>> from os.path import join as pjoin
-        >>> from pixyz.distributions import Normal
-        >>> tmpdir = '.'
-        >>> no_contiguous_tensor = torch.zeros(2, 3).T
-        >>> ones = torch.ones_like(no_contiguous_tensor)
-        >>> p = Normal(loc=no_contiguous_tensor, scale=ones)
-        >>> save_path = pjoin(tmpdir, "tmp.pt")
-        >>> torch.save(p.state_dict(), save_path)
-        >>> # it needs copy of tensor
-        >>> q = Normal(loc=ones, scale=ones)
-        >>> _ = q.load_state_dict(torch.load(save_path))
-        >>> assert torch.all(no_contiguous_tensor == q.loc).item()
         """
 
         self.replace_params_dict = {}


### PR DESCRIPTION
I found a bug regarding the saving/loading Pixyz object.

# 1. Probrem

First, I make `Normal` distributions with the same tensors. (`p.loc=q.loc=q.scale`)

```
>>> from pixyz.distributions import Normal
>>> ones=torch.ones(2)
>>> p=Normal(loc=torch.zeros(2), scale=ones)
>>> q=Normal(loc=ones, scale=ones)
```

Next, I make new distribution with different params & load them to old one.
```
>>> save_path = "./tmp.pt"
>>> torch.save(Normal(loc=torch.zeros(2), scale=2 * torch.ones(2)).state_dict(), save_path)
>>> q.load_state_dict(torch.load(save_path))
<All keys matched successfully>
```
Then, loaded params are not correct. Inplace-updates overwrites linked params.
```
>>> q.scale
tensor([[2., 2.]])
>>> q.loc
tensor([[2., 2.]])
>>> p.scale
tensor([[2., 2.]])
```

# 2. Change

This is because `DistributionBase` class treats buffered parameters as variables of Reference types. 

Therefore, I added the clone() method when registering features. Although it wastes memory, it correctly works.

And this change is related to pull request #110. Just cloning solve its issue, so I removed some lines.
