### PR TITLE
hot-fix for the bug of remaining future values

### DIFF
--- a/pixyz/losses/iteration.py
+++ b/pixyz/losses/iteration.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 import sympy
 
 from .losses import Loss
-from ..utils import get_dict_values
+from ..utils import get_dict_values, replace_dict_keys
 
 
 class IterativeLoss(Loss):
@@ -152,8 +152,7 @@ class IterativeLoss(Loss):
             step_loss_sum += step_loss
 
             # update
-            for key, value in self.update_value.items():
-                x_dict.update({value: x_dict[key]})
+            x_dict = replace_dict_keys(x_dict, self.update_value)
 
         loss = step_loss_sum
 


### PR DESCRIPTION
This is hot fix of IterativeLoss.

## Issue: a bug of IterativeLoss
1. `x_dict.update({value: x_dict[key]})` at line:156 register `key`-variable's value as `value`-variable's value. And `key`-variable remains.
2. At next step, `key`-variable are sometimes overwritten but sometimes not. For example, `AddLoss` copies an input dictionary, and overwrite old one to updated one.
3. the `key`-variable is not updated. So the effect of reccurence is ignored.

## Solution
- hotfix: delete future variable by replace_dict_keys.
- raise exception when some variables are overwritten by sampling (now preparing).