### PR TITLE
Fix/unupdated x dict

### DIFF
--- a/pixyz/distributions/exponential_distributions.py
+++ b/pixyz/distributions/exponential_distributions.py
@@ -123,18 +123,13 @@ class RelaxedBernoulli(Bernoulli):
 
     def sample(self, x_dict={}, batch_n=None, sample_shape=torch.Size(), return_all=True, reparam=False):
         # check whether the input is valid or convert it to valid dictionary.
-        x_dict = self._check_input(x_dict)
-        input_dict = {}
-
-        # conditioned
-        if len(self.input_var) != 0:
-            input_dict.update(get_dict_values(x_dict, self.input_var, return_dict=True))
+        input_dict = self._get_input_dict(x_dict)
 
         self.set_dist(input_dict, batch_n=batch_n, sampling=True)
-        output_dict = self.get_sample(reparam=reparam,
-                                      sample_shape=sample_shape)
+        output_dict = self.get_sample(reparam=reparam, sample_shape=sample_shape)
 
         if return_all:
+            x_dict = x_dict.copy()
             x_dict.update(output_dict)
             return x_dict
 
@@ -256,18 +251,13 @@ class RelaxedCategorical(Categorical):
 
     def sample(self, x_dict={}, batch_n=None, sample_shape=torch.Size(), return_all=True, reparam=False):
         # check whether the input is valid or convert it to valid dictionary.
-        x_dict = self._check_input(x_dict)
-        input_dict = {}
-
-        # conditioned
-        if len(self.input_var) != 0:
-            input_dict.update(get_dict_values(x_dict, self.input_var, return_dict=True))
+        input_dict = self._get_input_dict(x_dict)
 
         self.set_dist(input_dict, batch_n=batch_n, sampling=True)
-        output_dict = self.get_sample(reparam=reparam,
-                                      sample_shape=sample_shape)
+        output_dict = self.get_sample(reparam=reparam, sample_shape=sample_shape)
 
         if return_all:
+            x_dict = x_dict.copy()
             x_dict.update(output_dict)
             return x_dict
 

--- a/pixyz/distributions/mixture_distributions.py
+++ b/pixyz/distributions/mixture_distributions.py
@@ -139,7 +139,7 @@ class MixtureModel(Distribution):
     def posterior(self, name=None):
         return PosteriorMixtureModel(self, name=name)
 
-    def sample(self, batch_n=None, sample_shape=torch.Size(), return_hidden=False, **kwargs):
+    def sample(self, x_dict={}, batch_n=None, sample_shape=torch.Size(), return_all=True, return_hidden=False, **kwargs):
         # sample from prior
         hidden_output = self.prior.sample(batch_n=batch_n)[self._hidden_var[0]]
 
@@ -152,6 +152,11 @@ class MixtureModel(Distribution):
 
         if return_hidden:
             output_dict.update({self._hidden_var[0]: hidden_output})
+
+        if return_all:
+            x_dict = x_dict.copy()
+            x_dict.update(output_dict)
+            return x_dict
 
         return output_dict
 

--- a/pixyz/distributions/poe.py
+++ b/pixyz/distributions/poe.py
@@ -204,7 +204,7 @@ class ProductOfNormal(Normal):
 
         return output_loc, torch.sqrt(output_variance)
 
-    def _check_input(self, x, var=None):
+    def _get_input_dict(self, x, var=None):
         if var is None:
             var = self.input_var
 
@@ -222,7 +222,7 @@ class ProductOfNormal(Normal):
         else:
             raise ValueError("The type of input is not valid, got %s." % type(x))
 
-        return checked_x
+        return get_dict_values(checked_x, var, return_dict=True)
 
     def log_prob(self, sum_features=True, feature_dims=None):
         raise NotImplementedError()
@@ -306,26 +306,8 @@ class ElementWiseProductOfNormal(ProductOfNormal):
 
         super().__init__(p=p, name=name, features_shape=features_shape)
 
-    def _check_input(self, x, var=None):
-        if var is None:
-            var = self.input_var
-
-        if type(x) is torch.Tensor:
-            checked_x = {var[0]: x}
-
-        elif type(x) is list:
-            # TODO: we need to check if all the elements contained in this list are torch.Tensor.
-            checked_x = dict(zip(var, x))
-
-        elif type(x) is dict:
-            if not (set(list(x.keys())) >= set(var)):
-                raise ValueError("Input keys are not valid.")
-            checked_x = x
-
-        else:
-            raise ValueError("The type of input is not valid, got %s." % type(x))
-
-        return checked_x
+    def _get_input_dict(self, x, var=None):
+        return super(ProductOfNormal)._get_input_dict(x, var)
 
     @staticmethod
     def _get_mask(inputs, index):

--- a/pixyz/distributions/special_distributions.py
+++ b/pixyz/distributions/special_distributions.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 from .distributions import Distribution
-from ..utils import get_dict_values
 
 
 class Deterministic(Distribution):
@@ -42,14 +41,14 @@ class Deterministic(Distribution):
         return "Deterministic"
 
     def sample(self, x_dict={}, return_all=True, **kwargs):
-        x_dict = self._check_input(x_dict)
-        _x_dict = get_dict_values(x_dict, self.input_var, return_dict=True)
-        output_dict = self.forward(**_x_dict)
+        input_dict = self._get_input_dict(x_dict)
+        output_dict = self.forward(**input_dict)
 
         if set(output_dict.keys()) != set(self._var):
             raise ValueError("Output variables are not the same as `var`.")
 
         if return_all:
+            x_dict = x_dict.copy()
             x_dict.update(output_dict)
             return x_dict
 
@@ -92,7 +91,7 @@ class DataDistribution(Distribution):
         return "Data distribution"
 
     def sample(self, x_dict={}, **kwargs):
-        output_dict = self._check_input(x_dict)
+        output_dict = self._get_input_dict(x_dict)
         return output_dict
 
     def sample_mean(self, x_dict):

--- a/pixyz/losses/adversarial_loss.py
+++ b/pixyz/losses/adversarial_loss.py
@@ -402,12 +402,12 @@ class AdversarialKullbackLeibler(AdversarialLoss):
             # sample y_q from d
             y_q = get_dict_values(self.d.sample(detach_dict(x_q_dict)), self.d.var)[0]
 
-            return self.d_loss(y_p, y_q, batch_n), x_dict
+            return self.d_loss(y_p, y_q, batch_n), {}
 
         # sample y from d
         y_p = get_dict_values(self.d.sample(x_p_dict), self.d.var)[0]
 
-        return self.g_loss(y_p, batch_n), x_dict
+        return self.g_loss(y_p, batch_n), {}
 
     def g_loss(self, y_p, batch_n):
         """Evaluate a generator loss given an output of the discriminator.

--- a/pixyz/losses/divergences.py
+++ b/pixyz/losses/divergences.py
@@ -33,9 +33,6 @@ def KullbackLeibler(p, q, input_var=None, dim=None, analytical=True, sample_shap
     >>> loss_cls.eval() # doctest: +SKIP
     tensor([31.4713])
     """
-    if input_var is None:
-        input_var = p.input_var
-
     if analytical:
         loss = AnalyticalKullbackLeibler(p, q, input_var, dim)
     else:
@@ -45,6 +42,8 @@ def KullbackLeibler(p, q, input_var=None, dim=None, analytical=True, sample_shap
 
 class AnalyticalKullbackLeibler(Divergence):
     def __init__(self, p, q, input_var=None, dim=None):
+        if input_var is None:
+            input_var = list(set(p.input_var) | set(q.input_var))
         self.dim = dim
         super().__init__(p, q, input_var)
 
@@ -67,11 +66,11 @@ class AnalyticalKullbackLeibler(Divergence):
 
         if self.dim:
             divergence = torch.sum(divergence, dim=self.dim)
-            return divergence, x_dict
+            return divergence, {}
 
         dim_list = list(torch.arange(divergence.dim()))
         divergence = torch.sum(divergence, dim=dim_list[1:])
-        return divergence, x_dict
+        return divergence, {}
 
         """
         if (self._p1.distribution_name == "vonMisesFisher" and \

--- a/pixyz/losses/entropy.py
+++ b/pixyz/losses/entropy.py
@@ -33,8 +33,6 @@ def Entropy(p, input_var=None, analytical=True, sample_shape=torch.Size([1])):
     if analytical:
         loss = AnalyticalEntropy(p, input_var=input_var)
     else:
-        if input_var is None:
-            input_var = p.input_var
         loss = -p.log_prob().expectation(p, input_var, sample_shape=sample_shape)
     return loss
 
@@ -44,7 +42,7 @@ class AnalyticalEntropy(Loss):
         if input_var is None:
             _input_var = p.input_var.copy()
         else:
-            _input_var = input_var
+            _input_var = list(input_var)
         super().__init__(_input_var)
         self.p = p
 
@@ -60,7 +58,7 @@ class AnalyticalEntropy(Loss):
 
         entropy = self.p.get_entropy(x_dict)
 
-        return entropy, x_dict
+        return entropy, {}
 
 
 def CrossEntropy(p, q, input_var=None, analytical=False, sample_shape=torch.Size([1])):
@@ -92,9 +90,6 @@ def CrossEntropy(p, q, input_var=None, analytical=False, sample_shape=torch.Size
     if analytical:
         loss = Entropy(p) + KullbackLeibler(p, q)
     else:
-        if input_var is None:
-            input_var = list(set(p.input_var + q.input_var) - set(p.var))
-
         loss = -q.log_prob().expectation(p, input_var, sample_shape=sample_shape)
     return loss
 

--- a/pixyz/losses/iteration.py
+++ b/pixyz/losses/iteration.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 import sympy
 
 from .losses import Loss
-from ..utils import get_dict_values
+from ..utils import get_dict_values, replace_dict_keys
 
 
 class IterativeLoss(Loss):
@@ -152,8 +152,7 @@ class IterativeLoss(Loss):
             step_loss_sum += step_loss
 
             # update
-            for key, value in self.update_value.items():
-                x_dict.update({value: x_dict[key]})
+            x_dict = replace_dict_keys(x_dict, self.update_value)
 
         loss = step_loss_sum
 

--- a/pixyz/losses/iteration.py
+++ b/pixyz/losses/iteration.py
@@ -76,7 +76,7 @@ class IterativeLoss(Loss):
     """
 
     def __init__(self, step_loss, max_iter=None,
-                 input_var=None, series_var=None, update_value={}, slice_step=None, timestep_var=["t"]):
+                 series_var=None, update_value={}, slice_step=None, timestep_var=["t"]):
         super().__init__()
         self.step_loss = step_loss
         self.max_iter = max_iter
@@ -91,16 +91,15 @@ class IterativeLoss(Loss):
         if self.slice_step:
             self.step_loss = self.step_loss.expectation(self.slice_step)
 
-        if input_var is not None:
-            self._input_var = input_var
-        else:
-            _input_var = []
-            _input_var += deepcopy(self.step_loss.input_var)
+        _input_var = []
+        _input_var += deepcopy(self.step_loss.input_var)
+        _input_var += series_var
+        _input_var += update_value.values()
 
-            self._input_var = sorted(set(_input_var), key=_input_var.index)
+        self._input_var = sorted(set(_input_var), key=_input_var.index)
 
-            if slice_step:
-                self._input_var.remove(timestep_var[0])  # delete a time-step variable from input_var
+        if slice_step:
+            self._input_var.remove(timestep_var[0])  # delete a time-step variable from input_var
 
         self.series_var = series_var
 
@@ -145,7 +144,7 @@ class IterativeLoss(Loss):
                 x_dict.update(self.slice_step_fn(t, series_x_dict))
 
             # evaluate
-            step_loss, samples = self.step_loss.eval(x_dict, return_dict=True)
+            step_loss, samples = self.step_loss.eval(x_dict, return_dict=True, return_all=False)
             x_dict.update(samples)
             if mask is not None:
                 step_loss *= mask[t]
@@ -159,4 +158,5 @@ class IterativeLoss(Loss):
         # Restore original values
         x_dict.update(series_x_dict)
         x_dict.update(updated_x_dict)
+        # TODO: x_dict contains no-updated variables.
         return loss, x_dict

--- a/pixyz/losses/mmd.py
+++ b/pixyz/losses/mmd.py
@@ -86,7 +86,7 @@ class MMD(Divergence):
         pq_kernel = self.kernel(p_x, q_x, **self.kernel_params).sum() / (p_x_dim * q_x_dim)
         mmd_loss = p_kernel + q_kernel - 2 * pq_kernel
 
-        return mmd_loss, x_dict
+        return mmd_loss, {}
 
 
 def pairwise_distance_matrix(x, y, metric="euclidean"):

--- a/pixyz/losses/pdf.py
+++ b/pixyz/losses/pdf.py
@@ -40,7 +40,7 @@ class LogProb(Loss):
 
     def forward(self, x={}, **kwargs):
         log_prob = self.p.get_log_prob(x, sum_features=self.sum_features, feature_dims=self.feature_dims)
-        return log_prob, x
+        return log_prob, {}
 
 
 class Prob(LogProb):
@@ -72,4 +72,4 @@ class Prob(LogProb):
 
     def forward(self, x={}, **kwargs):
         log_prob, x = super().forward(x, **kwargs)
-        return torch.exp(log_prob), x
+        return torch.exp(log_prob), {}

--- a/pixyz/losses/wasserstein.py
+++ b/pixyz/losses/wasserstein.py
@@ -74,4 +74,4 @@ class WassersteinDistance(Divergence):
 
         distance = self.metric(p_x, q_x)
 
-        return distance, x_dict
+        return distance, {}


### PR DESCRIPTION
This is fix of IterativeLoss. (hot fix #114 is closed.)

## Issue: a bug of IterativeLoss
1. `x_dict.update({value: x_dict[key]})` at line:156 register `key`-variable's value as `value`-variable's value. And `key`-variable remains.
2. At next step, `key`-variable are sometimes overwritten but sometimes not. For example, `AddLoss` copies an input dictionary, and overwrite old one to updated one.
3. the `key`-variable is not updated. So the effect of reccurence is ignored.

## Solution
- delete future variable by replace_dict_keys at the step of IterativeLoss.
- get only updated variables from distribution.sample or loss.eval and override them to dictionary of all variables.
- fix some illegal operations to input dictionary
- fix wrong input_var of some losses
