### PR TITLE
Feature/dist graph

### DIFF
--- a/pixyz/distributions/custom_distributions.py
+++ b/pixyz/distributions/custom_distributions.py
@@ -40,7 +40,7 @@ class CustomProb(Distribution):
         self._log_prob_function = log_prob_function
         self._distribution_name = distribution_name
 
-        super().__init__(var=var, cond_var=[], **kwargs)
+        super().__init__(var=var, **kwargs)
 
     @property
     def log_prob_function(self):
@@ -62,6 +62,9 @@ class CustomProb(Distribution):
             log_prob = sum_samples(log_prob)
 
         return log_prob
+
+    def sample(self, x_dict={}, return_all=True, **kwargs):
+        raise NotImplementedError()
 
     @property
     def has_reparam(self):

--- a/pixyz/distributions/mixture_distributions.py
+++ b/pixyz/distributions/mixture_distributions.py
@@ -28,34 +28,35 @@ class MixtureModel(Distribution):
     >>> p = MixtureModel(distributions=distributions, prior=prior)
     >>> print(p)
     Distribution:
-      p(x) = p_{0}(x|z=0)prior(z=0) + p_{1}(x|z=1)prior(z=1) + p_{2}(x|z=2)prior(z=2)
+      p(x)
     Network architecture:
+      p(x) -> p_{0}(x|z=0)prior(z=0) + p_{1}(x|z=1)prior(z=1) + p_{2}(x|z=2)prior(z=2) =
       MixtureModel(
         name=p, distribution_name=Mixture Model,
-        var=['x'], cond_var=[], input_var=[], features_shape=torch.Size([])
+        features_shape=torch.Size([])
         (distributions): ModuleList(
           (0): Normal(
             name=p_{0}, distribution_name=Normal,
-            var=['x'], cond_var=[], input_var=[], features_shape=torch.Size([2])
+            features_shape=torch.Size([2])
             (loc): torch.Size([1, 2])
             (scale): torch.Size([1, 2])
           )
           (1): Normal(
             name=p_{1}, distribution_name=Normal,
-            var=['x'], cond_var=[], input_var=[], features_shape=torch.Size([2])
+            features_shape=torch.Size([2])
             (loc): torch.Size([1, 2])
             (scale): torch.Size([1, 2])
           )
           (2): Normal(
             name=p_{2}, distribution_name=Normal,
-            var=['x'], cond_var=[], input_var=[], features_shape=torch.Size([2])
+            features_shape=torch.Size([2])
             (loc): torch.Size([1, 2])
             (scale): torch.Size([1, 2])
           )
         )
         (prior): Categorical(
           name=prior, distribution_name=Categorical,
-          var=['z'], cond_var=[], input_var=[], features_shape=torch.Size([3])
+          features_shape=torch.Size([3])
           (probs): torch.Size([1, 3])
         )
       )
@@ -110,14 +111,6 @@ class MixtureModel(Distribution):
     def hidden_var(self):
         """list: Hidden variables of this distribution."""
         return self._hidden_var
-
-    @property
-    def prob_text(self):
-        _prob_text = "{}({})".format(
-            self._name, ','.join(([convert_latex_name(var_name) for var_name in self._var]))
-        )
-
-        return _prob_text
 
     @property
     def prob_factorized_text(self):

--- a/pixyz/distributions/mixture_distributions.py
+++ b/pixyz/distributions/mixture_distributions.py
@@ -33,30 +33,30 @@ class MixtureModel(Distribution):
       p(x) -> p_{0}(x|z=0)prior(z=0) + p_{1}(x|z=1)prior(z=1) + p_{2}(x|z=2)prior(z=2) =
       MixtureModel(
         name=p, distribution_name=Mixture Model,
-        features_shape=torch.Size([])
+        var=['x'], cond_var=[], input_var=[], features_shape=torch.Size([])
         (distributions): ModuleList(
           (0): Normal(
             name=p_{0}, distribution_name=Normal,
-            features_shape=torch.Size([2])
+            var=['x'], cond_var=[], input_var=[], features_shape=torch.Size([2])
             (loc): torch.Size([1, 2])
             (scale): torch.Size([1, 2])
           )
           (1): Normal(
             name=p_{1}, distribution_name=Normal,
-            features_shape=torch.Size([2])
+            var=['x'], cond_var=[], input_var=[], features_shape=torch.Size([2])
             (loc): torch.Size([1, 2])
             (scale): torch.Size([1, 2])
           )
           (2): Normal(
             name=p_{2}, distribution_name=Normal,
-            features_shape=torch.Size([2])
+            var=['x'], cond_var=[], input_var=[], features_shape=torch.Size([2])
             (loc): torch.Size([1, 2])
             (scale): torch.Size([1, 2])
           )
         )
         (prior): Categorical(
           name=prior, distribution_name=Categorical,
-          features_shape=torch.Size([3])
+          var=['z'], cond_var=[], input_var=[], features_shape=torch.Size([3])
           (probs): torch.Size([1, 3])
         )
       )

--- a/pixyz/distributions/mixture_distributions.py
+++ b/pixyz/distributions/mixture_distributions.py
@@ -28,9 +28,8 @@ class MixtureModel(Distribution):
     >>> p = MixtureModel(distributions=distributions, prior=prior)
     >>> print(p)
     Distribution:
-      p(x)
+      p(x) = p_{0}(x|z=0)prior(z=0) + p_{1}(x|z=1)prior(z=1) + p_{2}(x|z=2)prior(z=2)
     Network architecture:
-      p(x) -> p_{0}(x|z=0)prior(z=0) + p_{1}(x|z=1)prior(z=1) + p_{2}(x|z=2)prior(z=2) =
       MixtureModel(
         name=p, distribution_name=Mixture Model,
         var=['x'], cond_var=[], input_var=[], features_shape=torch.Size([])

--- a/pixyz/distributions/special_distributions.py
+++ b/pixyz/distributions/special_distributions.py
@@ -24,7 +24,7 @@ class Deterministic(Distribution):
       p(x|z) =
       Generator(
         name=p, distribution_name=Deterministic,
-        features_shape=torch.Size([])
+        var=['x'], cond_var=['z'], input_var=['z'], features_shape=torch.Size([])
         (model): Linear(in_features=64, out_features=512, bias=True)
       )
     >>> sample = p.sample({"z": torch.randn(1, 64)})
@@ -88,7 +88,7 @@ class DataDistribution(Distribution):
       p_{data}(x) =
       DataDistribution(
         name=p_{data}, distribution_name=Data distribution,
-        features_shape=torch.Size([])
+        var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
       )
     >>> sample = p.sample({"x": torch.randn(1, 64)})
     """

--- a/pixyz/distributions/special_distributions.py
+++ b/pixyz/distributions/special_distributions.py
@@ -30,7 +30,7 @@ class Deterministic(Distribution):
     >>> p.log_prob().eval(sample) # log_prob is not defined.
     Traceback (most recent call last):
      ...
-    NotImplementedError
+    NotImplementedError: Log probability of deterministic distribution is not defined.
     """
 
     def __init__(self, var, cond_var=[], name='p', **kwargs):

--- a/pixyz/distributions/special_distributions.py
+++ b/pixyz/distributions/special_distributions.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-from .distributions import Distribution, DistGraph
+from .distributions import Distribution
 
 
 class Deterministic(Distribution):
@@ -21,9 +21,10 @@ class Deterministic(Distribution):
     Distribution:
       p(x|z)
     Network architecture:
+      p(x|z) =
       Generator(
         name=p, distribution_name=Deterministic,
-        var=['x'], cond_var=['z'], input_var=['z'], features_shape=torch.Size([])
+        features_shape=torch.Size([])
         (model): Linear(in_features=64, out_features=512, bias=True)
       )
     >>> sample = p.sample({"z": torch.randn(1, 64)})
@@ -33,9 +34,8 @@ class Deterministic(Distribution):
     NotImplementedError
     """
 
-    def __init__(self, name='p', **kwargs):
-        super().__init__(name=name, **kwargs)
-        self.graph = DistGraph().appended(self, name=name)
+    def __init__(self, var, cond_var=(), name='p', **kwargs):
+        super().__init__(var=var, cond_var=cond_var, name=name, **kwargs)
 
     @property
     def distribution_name(self):
@@ -85,16 +85,16 @@ class DataDistribution(Distribution):
     Distribution:
       p_{data}(x)
     Network architecture:
+      p_{data}(x) =
       DataDistribution(
         name=p_{data}, distribution_name=Data distribution,
-        var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
+        features_shape=torch.Size([])
       )
     >>> sample = p.sample({"x": torch.randn(1, 64)})
     """
 
     def __init__(self, var, name="p_{data}"):
         super().__init__(var=var, cond_var=[], name=name)
-        self.graph = DistGraph().appended(self, name=name)
 
     @property
     def distribution_name(self):
@@ -106,6 +106,9 @@ class DataDistribution(Distribution):
 
     def sample_mean(self, x_dict):
         return self.sample(x_dict, return_all=False)[self._var[0]]
+
+    def get_log_prob(self, x_dict, sum_features=True, feature_dims=None):
+        raise NotImplementedError()
 
     @property
     def input_var(self):

--- a/pixyz/distributions/special_distributions.py
+++ b/pixyz/distributions/special_distributions.py
@@ -21,7 +21,6 @@ class Deterministic(Distribution):
     Distribution:
       p(x|z)
     Network architecture:
-      p(x|z) =
       Generator(
         name=p, distribution_name=Deterministic,
         var=['x'], cond_var=['z'], input_var=['z'], features_shape=torch.Size([])
@@ -34,7 +33,7 @@ class Deterministic(Distribution):
     NotImplementedError
     """
 
-    def __init__(self, var, cond_var=(), name='p', **kwargs):
+    def __init__(self, var, cond_var=[], name='p', **kwargs):
         super().__init__(var=var, cond_var=cond_var, name=name, **kwargs)
 
     @property
@@ -59,16 +58,11 @@ class Deterministic(Distribution):
         return self.sample(x_dict, return_all=False)[self._var[0]]
 
     def get_log_prob(self, x_dict, sum_features=True, feature_dims=None):
-        raise NotImplementedError()
+        raise NotImplementedError("Log probability of deterministic distribution is not defined.")
 
     @property
     def has_reparam(self):
         return True
-
-    @property
-    def prob_factorized_text(self):
-        """str: Return a formula of the factorized probability distribution."""
-        return self.prob_text
 
 
 class DataDistribution(Distribution):
@@ -85,7 +79,6 @@ class DataDistribution(Distribution):
     Distribution:
       p_{data}(x)
     Network architecture:
-      p_{data}(x) =
       DataDistribution(
         name=p_{data}, distribution_name=Data distribution,
         var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
@@ -121,8 +114,3 @@ class DataDistribution(Distribution):
     @property
     def has_reparam(self):
         return True
-
-    @property
-    def prob_factorized_text(self):
-        """str: Return a formula of the factorized probability distribution."""
-        return self.prob_text

--- a/pixyz/distributions/special_distributions.py
+++ b/pixyz/distributions/special_distributions.py
@@ -93,8 +93,13 @@ class DataDistribution(Distribution):
     def distribution_name(self):
         return "Data distribution"
 
-    def sample(self, x_dict={}, **kwargs):
+    def sample(self, x_dict={}, return_all=True, **kwargs):
         output_dict = self._get_input_dict(x_dict)
+
+        if return_all:
+            x_dict = x_dict.copy()
+            x_dict.update(output_dict)
+            return x_dict
         return output_dict
 
     def sample_mean(self, x_dict):

--- a/pixyz/distributions/special_distributions.py
+++ b/pixyz/distributions/special_distributions.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-from .distributions import Distribution
+from .distributions import Distribution, DistGraph
 
 
 class Deterministic(Distribution):
@@ -33,8 +33,9 @@ class Deterministic(Distribution):
     NotImplementedError
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, name='p', **kwargs):
+        super().__init__(name=name, **kwargs)
+        self.graph = DistGraph().appended(self, name=name)
 
     @property
     def distribution_name(self):
@@ -57,9 +58,17 @@ class Deterministic(Distribution):
     def sample_mean(self, x_dict):
         return self.sample(x_dict, return_all=False)[self._var[0]]
 
+    def get_log_prob(self, x_dict, sum_features=True, feature_dims=None):
+        raise NotImplementedError()
+
     @property
     def has_reparam(self):
         return True
+
+    @property
+    def prob_factorized_text(self):
+        """str: Return a formula of the factorized probability distribution."""
+        return self.prob_text
 
 
 class DataDistribution(Distribution):
@@ -85,6 +94,7 @@ class DataDistribution(Distribution):
 
     def __init__(self, var, name="p_{data}"):
         super().__init__(var=var, cond_var=[], name=name)
+        self.graph = DistGraph().appended(self, name=name)
 
     @property
     def distribution_name(self):
@@ -108,3 +118,8 @@ class DataDistribution(Distribution):
     @property
     def has_reparam(self):
         return True
+
+    @property
+    def prob_factorized_text(self):
+        """str: Return a formula of the factorized probability distribution."""
+        return self.prob_text

--- a/pixyz/losses/adversarial_loss.py
+++ b/pixyz/losses/adversarial_loss.py
@@ -171,7 +171,6 @@ class AdversarialJensenShannon(AdversarialLoss):
     Distribution:
       p_{data}(x)
     Network architecture:
-      p_{data}(x) =
       DataDistribution(
         name=p_{data}, distribution_name=Data distribution,
         var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
@@ -188,7 +187,6 @@ class AdversarialJensenShannon(AdversarialLoss):
     Distribution:
       d(t|x)
     Network architecture:
-      d(t|x) =
       Discriminator(
         name=d, distribution_name=Deterministic,
         var=['t'], cond_var=['x'], input_var=['x'], features_shape=torch.Size([])
@@ -340,7 +338,6 @@ class AdversarialKullbackLeibler(AdversarialLoss):
     Distribution:
       p_{data}(x)
     Network architecture:
-      p_{data}(x) =
       DataDistribution(
         name=p_{data}, distribution_name=Data distribution,
         var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
@@ -357,7 +354,6 @@ class AdversarialKullbackLeibler(AdversarialLoss):
     Distribution:
       d(t|x)
     Network architecture:
-      d(t|x) =
       Discriminator(
         name=d, distribution_name=Deterministic,
         var=['t'], cond_var=['x'], input_var=['x'], features_shape=torch.Size([])
@@ -500,7 +496,6 @@ class AdversarialWassersteinDistance(AdversarialJensenShannon):
     Distribution:
       p_{data}(x)
     Network architecture:
-      p_{data}(x) =
       DataDistribution(
         name=p_{data}, distribution_name=Data distribution,
         var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
@@ -517,7 +512,6 @@ class AdversarialWassersteinDistance(AdversarialJensenShannon):
     Distribution:
       d(t|x)
     Network architecture:
-      d(t|x) =
       Discriminator(
         name=d, distribution_name=Deterministic,
         var=['t'], cond_var=['x'], input_var=['x'], features_shape=torch.Size([])

--- a/pixyz/losses/adversarial_loss.py
+++ b/pixyz/losses/adversarial_loss.py
@@ -155,14 +155,14 @@ class AdversarialJensenShannon(AdversarialLoss):
       p_{prior}(z) =
       Normal(
         name=p_{prior}, distribution_name=Normal,
-        features_shape=torch.Size([32])
+        var=['z'], cond_var=[], input_var=[], features_shape=torch.Size([32])
         (loc): torch.Size([1, 32])
         (scale): torch.Size([1, 32])
       )
       p(x|z) =
       Generator(
         name=p, distribution_name=Deterministic,
-        features_shape=torch.Size([])
+        var=['x'], cond_var=['z'], input_var=['z'], features_shape=torch.Size([])
         (model): Linear(in_features=32, out_features=64, bias=True)
       )
     >>> # Data distribution (dummy distribution)
@@ -174,7 +174,7 @@ class AdversarialJensenShannon(AdversarialLoss):
       p_{data}(x) =
       DataDistribution(
         name=p_{data}, distribution_name=Data distribution,
-        features_shape=torch.Size([])
+        var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
       )
     >>> # Discriminator (critic)
     >>> class Discriminator(Deterministic):
@@ -191,7 +191,7 @@ class AdversarialJensenShannon(AdversarialLoss):
       d(t|x) =
       Discriminator(
         name=d, distribution_name=Deterministic,
-        features_shape=torch.Size([])
+        var=['t'], cond_var=['x'], input_var=['x'], features_shape=torch.Size([])
         (model): Linear(in_features=64, out_features=1, bias=True)
       )
     >>>
@@ -324,14 +324,14 @@ class AdversarialKullbackLeibler(AdversarialLoss):
       p_{prior}(z) =
       Normal(
         name=p_{prior}, distribution_name=Normal,
-        features_shape=torch.Size([32])
+        var=['z'], cond_var=[], input_var=[], features_shape=torch.Size([32])
         (loc): torch.Size([1, 32])
         (scale): torch.Size([1, 32])
       )
       p(x|z) =
       Generator(
         name=p, distribution_name=Deterministic,
-        features_shape=torch.Size([])
+        var=['x'], cond_var=['z'], input_var=['z'], features_shape=torch.Size([])
         (model): Linear(in_features=32, out_features=64, bias=True)
       )
     >>> # Data distribution (dummy distribution)
@@ -343,7 +343,7 @@ class AdversarialKullbackLeibler(AdversarialLoss):
       p_{data}(x) =
       DataDistribution(
         name=p_{data}, distribution_name=Data distribution,
-        features_shape=torch.Size([])
+        var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
       )
     >>> # Discriminator (critic)
     >>> class Discriminator(Deterministic):
@@ -360,7 +360,7 @@ class AdversarialKullbackLeibler(AdversarialLoss):
       d(t|x) =
       Discriminator(
         name=d, distribution_name=Deterministic,
-        features_shape=torch.Size([])
+        var=['t'], cond_var=['x'], input_var=['x'], features_shape=torch.Size([])
         (model): Linear(in_features=64, out_features=1, bias=True)
       )
     >>>
@@ -484,14 +484,14 @@ class AdversarialWassersteinDistance(AdversarialJensenShannon):
       p_{prior}(z) =
       Normal(
         name=p_{prior}, distribution_name=Normal,
-        features_shape=torch.Size([32])
+        var=['z'], cond_var=[], input_var=[], features_shape=torch.Size([32])
         (loc): torch.Size([1, 32])
         (scale): torch.Size([1, 32])
       )
       p(x|z) =
       Generator(
         name=p, distribution_name=Deterministic,
-        features_shape=torch.Size([])
+        var=['x'], cond_var=['z'], input_var=['z'], features_shape=torch.Size([])
         (model): Linear(in_features=32, out_features=64, bias=True)
       )
     >>> # Data distribution (dummy distribution)
@@ -503,7 +503,7 @@ class AdversarialWassersteinDistance(AdversarialJensenShannon):
       p_{data}(x) =
       DataDistribution(
         name=p_{data}, distribution_name=Data distribution,
-        features_shape=torch.Size([])
+        var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
       )
     >>> # Discriminator (critic)
     >>> class Discriminator(Deterministic):
@@ -520,7 +520,7 @@ class AdversarialWassersteinDistance(AdversarialJensenShannon):
       d(t|x) =
       Discriminator(
         name=d, distribution_name=Deterministic,
-        features_shape=torch.Size([])
+        var=['t'], cond_var=['x'], input_var=['x'], features_shape=torch.Size([])
         (model): Linear(in_features=64, out_features=1, bias=True)
       )
     >>>

--- a/pixyz/losses/adversarial_loss.py
+++ b/pixyz/losses/adversarial_loss.py
@@ -152,15 +152,17 @@ class AdversarialJensenShannon(AdversarialLoss):
     Distribution:
       p(x) = \int p(x|z)p_{prior}(z)dz
     Network architecture:
+      p_{prior}(z) =
       Normal(
         name=p_{prior}, distribution_name=Normal,
-        var=['z'], cond_var=[], input_var=[], features_shape=torch.Size([32])
+        features_shape=torch.Size([32])
         (loc): torch.Size([1, 32])
         (scale): torch.Size([1, 32])
       )
+      p(x|z) =
       Generator(
         name=p, distribution_name=Deterministic,
-        var=['x'], cond_var=['z'], input_var=['z'], features_shape=torch.Size([])
+        features_shape=torch.Size([])
         (model): Linear(in_features=32, out_features=64, bias=True)
       )
     >>> # Data distribution (dummy distribution)
@@ -169,9 +171,10 @@ class AdversarialJensenShannon(AdversarialLoss):
     Distribution:
       p_{data}(x)
     Network architecture:
+      p_{data}(x) =
       DataDistribution(
         name=p_{data}, distribution_name=Data distribution,
-        var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
+        features_shape=torch.Size([])
       )
     >>> # Discriminator (critic)
     >>> class Discriminator(Deterministic):
@@ -185,9 +188,10 @@ class AdversarialJensenShannon(AdversarialLoss):
     Distribution:
       d(t|x)
     Network architecture:
+      d(t|x) =
       Discriminator(
         name=d, distribution_name=Deterministic,
-        var=['t'], cond_var=['x'], input_var=['x'], features_shape=torch.Size([])
+        features_shape=torch.Size([])
         (model): Linear(in_features=64, out_features=1, bias=True)
       )
     >>>
@@ -317,15 +321,17 @@ class AdversarialKullbackLeibler(AdversarialLoss):
     Distribution:
       p(x) = \int p(x|z)p_{prior}(z)dz
     Network architecture:
+      p_{prior}(z) =
       Normal(
         name=p_{prior}, distribution_name=Normal,
-        var=['z'], cond_var=[], input_var=[], features_shape=torch.Size([32])
+        features_shape=torch.Size([32])
         (loc): torch.Size([1, 32])
         (scale): torch.Size([1, 32])
       )
+      p(x|z) =
       Generator(
         name=p, distribution_name=Deterministic,
-        var=['x'], cond_var=['z'], input_var=['z'], features_shape=torch.Size([])
+        features_shape=torch.Size([])
         (model): Linear(in_features=32, out_features=64, bias=True)
       )
     >>> # Data distribution (dummy distribution)
@@ -334,9 +340,10 @@ class AdversarialKullbackLeibler(AdversarialLoss):
     Distribution:
       p_{data}(x)
     Network architecture:
+      p_{data}(x) =
       DataDistribution(
         name=p_{data}, distribution_name=Data distribution,
-        var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
+        features_shape=torch.Size([])
       )
     >>> # Discriminator (critic)
     >>> class Discriminator(Deterministic):
@@ -350,9 +357,10 @@ class AdversarialKullbackLeibler(AdversarialLoss):
     Distribution:
       d(t|x)
     Network architecture:
+      d(t|x) =
       Discriminator(
         name=d, distribution_name=Deterministic,
-        var=['t'], cond_var=['x'], input_var=['x'], features_shape=torch.Size([])
+        features_shape=torch.Size([])
         (model): Linear(in_features=64, out_features=1, bias=True)
       )
     >>>
@@ -473,15 +481,17 @@ class AdversarialWassersteinDistance(AdversarialJensenShannon):
     Distribution:
       p(x) = \int p(x|z)p_{prior}(z)dz
     Network architecture:
+      p_{prior}(z) =
       Normal(
         name=p_{prior}, distribution_name=Normal,
-        var=['z'], cond_var=[], input_var=[], features_shape=torch.Size([32])
+        features_shape=torch.Size([32])
         (loc): torch.Size([1, 32])
         (scale): torch.Size([1, 32])
       )
+      p(x|z) =
       Generator(
         name=p, distribution_name=Deterministic,
-        var=['x'], cond_var=['z'], input_var=['z'], features_shape=torch.Size([])
+        features_shape=torch.Size([])
         (model): Linear(in_features=32, out_features=64, bias=True)
       )
     >>> # Data distribution (dummy distribution)
@@ -490,9 +500,10 @@ class AdversarialWassersteinDistance(AdversarialJensenShannon):
     Distribution:
       p_{data}(x)
     Network architecture:
+      p_{data}(x) =
       DataDistribution(
         name=p_{data}, distribution_name=Data distribution,
-        var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
+        features_shape=torch.Size([])
       )
     >>> # Discriminator (critic)
     >>> class Discriminator(Deterministic):
@@ -506,9 +517,10 @@ class AdversarialWassersteinDistance(AdversarialJensenShannon):
     Distribution:
       d(t|x)
     Network architecture:
+      d(t|x) =
       Discriminator(
         name=d, distribution_name=Deterministic,
-        var=['t'], cond_var=['x'], input_var=['x'], features_shape=torch.Size([])
+        features_shape=torch.Size([])
         (model): Linear(in_features=64, out_features=1, bias=True)
       )
     >>>

--- a/pixyz/losses/adversarial_loss.py
+++ b/pixyz/losses/adversarial_loss.py
@@ -152,14 +152,14 @@ class AdversarialJensenShannon(AdversarialLoss):
     Distribution:
       p(x) = \int p(x|z)p_{prior}(z)dz
     Network architecture:
-      p_{prior}(z) =
+      p_{prior}(z):
       Normal(
         name=p_{prior}, distribution_name=Normal,
         var=['z'], cond_var=[], input_var=[], features_shape=torch.Size([32])
         (loc): torch.Size([1, 32])
         (scale): torch.Size([1, 32])
       )
-      p(x|z) =
+      p(x|z):
       Generator(
         name=p, distribution_name=Deterministic,
         var=['x'], cond_var=['z'], input_var=['z'], features_shape=torch.Size([])
@@ -319,14 +319,14 @@ class AdversarialKullbackLeibler(AdversarialLoss):
     Distribution:
       p(x) = \int p(x|z)p_{prior}(z)dz
     Network architecture:
-      p_{prior}(z) =
+      p_{prior}(z):
       Normal(
         name=p_{prior}, distribution_name=Normal,
         var=['z'], cond_var=[], input_var=[], features_shape=torch.Size([32])
         (loc): torch.Size([1, 32])
         (scale): torch.Size([1, 32])
       )
-      p(x|z) =
+      p(x|z):
       Generator(
         name=p, distribution_name=Deterministic,
         var=['x'], cond_var=['z'], input_var=['z'], features_shape=torch.Size([])
@@ -477,14 +477,14 @@ class AdversarialWassersteinDistance(AdversarialJensenShannon):
     Distribution:
       p(x) = \int p(x|z)p_{prior}(z)dz
     Network architecture:
-      p_{prior}(z) =
+      p_{prior}(z):
       Normal(
         name=p_{prior}, distribution_name=Normal,
         var=['z'], cond_var=[], input_var=[], features_shape=torch.Size([32])
         (loc): torch.Size([1, 32])
         (scale): torch.Size([1, 32])
       )
-      p(x|z) =
+      p(x|z):
       Generator(
         name=p, distribution_name=Deterministic,
         var=['x'], cond_var=['z'], input_var=['z'], features_shape=torch.Size([])

--- a/pixyz/losses/iteration.py
+++ b/pixyz/losses/iteration.py
@@ -61,11 +61,11 @@ class IterativeLoss(Loss):
     >>> # Set the loss class
     >>> step_loss_cls = p.log_prob().expectation(q * f).mean()
     >>> print(step_loss_cls)
-    mean \left(\mathbb{E}_{p(z,h|x,h_{prev})} \left[\log p(x|z,h_{prev}) \right] \right)
+    mean \left(\mathbb{E}_{q(z,h|x,h_{prev})} \left[\log p(x|z,h_{prev}) \right] \right)
     >>> loss_cls = IterativeLoss(step_loss=step_loss_cls,
     ...                          series_var=["x"], update_value={"h": "h_prev"})
     >>> print(loss_cls)
-    \sum_{t=1}^{t_{max}} mean \left(\mathbb{E}_{p(z,h|x,h_{prev})} \left[\log p(x|z,h_{prev}) \right] \right)
+    \sum_{t=1}^{t_{max}} mean \left(\mathbb{E}_{q(z,h|x,h_{prev})} \left[\log p(x|z,h_{prev}) \right] \right)
     >>>
     >>> # Evaluate
     >>> x_sample = torch.randn(30, 2, 128) # (timestep_size, batch_size, feature_size)

--- a/pixyz/losses/iteration.py
+++ b/pixyz/losses/iteration.py
@@ -61,11 +61,11 @@ class IterativeLoss(Loss):
     >>> # Set the loss class
     >>> step_loss_cls = p.log_prob().expectation(q * f).mean()
     >>> print(step_loss_cls)
-    mean \left(\mathbb{E}_{p(h,z|x,h_{prev})} \left[\log p(x|z,h_{prev}) \right] \right)
+    mean \left(\mathbb{E}_{p(z,h|x,h_{prev})} \left[\log p(x|z,h_{prev}) \right] \right)
     >>> loss_cls = IterativeLoss(step_loss=step_loss_cls,
     ...                          series_var=["x"], update_value={"h": "h_prev"})
     >>> print(loss_cls)
-    \sum_{t=1}^{t_{max}} mean \left(\mathbb{E}_{p(h,z|x,h_{prev})} \left[\log p(x|z,h_{prev}) \right] \right)
+    \sum_{t=1}^{t_{max}} mean \left(\mathbb{E}_{p(z,h|x,h_{prev})} \left[\log p(x|z,h_{prev}) \right] \right)
     >>>
     >>> # Evaluate
     >>> x_sample = torch.randn(30, 2, 128) # (timestep_size, batch_size, feature_size)

--- a/pixyz/utils.py
+++ b/pixyz/utils.py
@@ -357,6 +357,8 @@ def print_latex(obj):
 
     if isinstance(obj, pixyz.distributions.distributions.Distribution):
         latex_text = obj.prob_joint_factorized_and_text
+    elif isinstance(obj, pixyz.distributions.distributions.DistGraph):
+        latex_text = obj.prob_joint_factorized_and_text
     elif isinstance(obj, pixyz.losses.losses.Loss):
         latex_text = obj.loss_text
     elif isinstance(obj, pixyz.models.model.Model):

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         "tensorboardX",
         "networkx",
     ],
-    # TODO: license of networkx
     license='MIT',
     classifiers=[
         'Programming Language :: Python :: 3.5',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,9 @@ setup(
         "sympy>=1.4",
         "ipython",
         "tensorboardX",
+        "networkx",
     ],
+    # TODO: license of networkx
     license='MIT',
     classifiers=[
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
In order to treat the graphical model as a graph, I introduced the `DistGraph` class and transferred the processing inside the `Distribution` class to it.

## Issues

- **Data format of not the graph but the expression tree:** The graphical model is defined as a composition tree that consists of the expression tree of the probability distribution, and the data format is not suitable for checking and manipulating the graph.
- **Difficulty in expanding the functionality of the entire graph:** The computation graph for conventional Distribution classes is represented by a method chain of the composition tree. If each node does not perform the same function as the atomic distribution, the computation graph will not work as a unified one. This runs the risk of scattered code when defining a new composite distribution class such as DetachDistribution or when adding new options to sample, get_log_prob.
- **Inefficient memoization for speedup:** In order to avoid duplication of calculations, ids are assigned to all intermediate calculations and memoized. Since the calculation graph of pytorch is held in the intermediate calculation that is not detached, the capacity of the memo increases immediately.

## Solution

I represent a graphical model with a graph object managed by `DistGraph`. Atomic distributions belong to the `Factor` class, and are the nodes of the graph.

- **Data format of expression tree, not graph** -> Use `networkx.DiGraph` inside `DistGraph`. This is a (factor) graph with two types of nodes: variable names and `Factor`s.
- **Difficulty in expanding the functionality of the entire graph** -> An atomic distribution is located at a `Factor` node on the graph and managed by `DistGraph` directly. Evaluation strategies for graphical models such as distribution of variable dictionaries and options can be centrally managed with `DistGraph`.
- **Inefficient memoization for speedup** -> If a computation graph is generated from a graphical model, it may be possible to reduce duplications of the same calculation by fusion of computation graphs in the future.

## Other design motives

- The reason why the graph has two types of nodes, variable name and `Factor`, is to allow an atomic distribution with multiple random variables such as `MixtureModel` with `return_hidden=True`.
- The reason why `Distribution` has `DistGraph` is that I want to maintain the merit of `Distribution` as the composition tree of `torch.nn.Module`. Since the atomic distribution is registered as the child module of `DistGraph`, `nn.Module.parameters()` still works at `Distribution` class. To avoid an infinite loop, the atomic distribution does not compose a `DistGraph`, just generate it as a property.