### PR TITLE
Fix/call module

### DIFF
--- a/pixyz/distributions/distributions.py
+++ b/pixyz/distributions/distributions.py
@@ -773,7 +773,7 @@ class DistributionBase(Distribution):
     @lru_cache_for_sample_dict()
     def get_params(self, params_dict={}, **kwargs):
         params_dict, vars_dict = replace_dict_keys_split(params_dict, self.replace_params_dict)
-        output_dict = self.forward(**vars_dict)
+        output_dict = self(**vars_dict)
 
         output_dict.update(params_dict)
 
@@ -1067,7 +1067,7 @@ class ReplaceVarDistribution(Distribution):
         self._input_var = _input_var
 
     def forward(self, *args, **kwargs):
-        return self.p.forward(*args, **kwargs)
+        return self.p(*args, **kwargs)
 
     def get_params(self, params_dict={}):
         params_dict = replace_dict_keys(params_dict, self._replace_inv_cond_var_dict)
@@ -1204,7 +1204,7 @@ class MarginalizeVarDistribution(Distribution):
         self._marginalize_list = marginalize_list
 
     def forward(self, *args, **kwargs):
-        return self.p.forward(*args, **kwargs)
+        return self.p(*args, **kwargs)
 
     def get_params(self, params_dict={}):
         return self.p.get_params(params_dict)

--- a/pixyz/losses/losses.py
+++ b/pixyz/losses/losses.py
@@ -208,7 +208,7 @@ class Loss(torch.nn.Module, metaclass=abc.ABCMeta):
                                                                                         list(x_dict.keys())))
 
         input_dict = get_dict_values(x_dict, self.input_var, return_dict=True)
-        loss, eval_dict = self.forward(input_dict, **kwargs)
+        loss, eval_dict = self(input_dict, **kwargs)
 
         if return_dict:
             output_dict = x_dict.copy() if return_all else {}


### PR DESCRIPTION
You can use hooks by calling nn.Module .__ call__ instead of nn.Module.forward.