### PR TITLE
support the case Normal(loc='y', scale='y',...)

### DIFF
--- a/pixyz/distributions/distributions.py
+++ b/pixyz/distributions/distributions.py
@@ -4,7 +4,7 @@ import re
 from torch import nn
 from copy import deepcopy
 
-from ..utils import get_dict_values, replace_dict_keys, replace_dict_keys_split, delete_dict_values,\
+from ..utils import get_dict_values, replace_dict_keys, delete_dict_values,\
     tolist, sum_samples, convert_latex_name, lru_cache_for_sample_dict
 from ..losses import LogProb, Prob
 
@@ -653,7 +653,9 @@ class DistributionBase(Distribution):
         for key in params_dict.keys():
             if type(params_dict[key]) is str:
                 if params_dict[key] in self._cond_var:
-                    self.replace_params_dict[params_dict[key]] = key
+                    if params_dict[key] not in self.replace_params_dict:
+                        self.replace_params_dict[params_dict[key]] = []
+                    self.replace_params_dict[params_dict[key]].append(key)
                 else:
                     raise ValueError("parameter setting {}:{} is not valid because cond_var does not contains {}."
                                      .format(key, params_dict[key], params_dict[key]))
@@ -772,10 +774,17 @@ class DistributionBase(Distribution):
 
     @lru_cache_for_sample_dict()
     def get_params(self, params_dict={}, **kwargs):
-        params_dict, vars_dict = replace_dict_keys_split(params_dict, self.replace_params_dict)
+        replaced_params_dict = {}
+        for key, value in params_dict.items():
+            if key in self.replace_params_dict:
+                for replaced_key in self.replace_params_dict[key]:
+                    replaced_params_dict[replaced_key] = value
+
+        vars_dict = {key: value for key, value in params_dict.items() if key not in self.replace_params_dict}
+
         output_dict = self.forward(**vars_dict)
 
-        output_dict.update(params_dict)
+        output_dict.update(replaced_params_dict)
 
         # append constant parameters to output_dict
         constant_params_dict = get_dict_values(dict(self.named_buffers()), self.params_keys,

--- a/tests/distributions/test_expornential_distributions.py
+++ b/tests/distributions/test_expornential_distributions.py
@@ -119,6 +119,13 @@ def test_save_dist(tmpdir, no_contiguous_tensor):
     assert torch.all(no_contiguous_tensor == q.loc).item()
 
 
+class TestNormal:
+    def test_init_with_same_param(self):
+        n = Normal(var=['x'], cond_var=['y'], loc='y', scale='y')
+        result = n.sample({'y': torch.ones(2, 3)})
+        assert result['x'].shape == (2, 3)
+
+
 class TestRelaxedBernoulli:
     def test_log_prob_of_hard_value(self):
         rb = RelaxedBernoulli(var=['x'], probs=torch.ones(2), temperature=torch.tensor(0.5))


### PR DESCRIPTION
## 目的

DistributionBaseを継承する全てのDistributionで，同じ確率変数をパラメータとして指定するとエラーになるので修正しました．

## 内容

`loc = 'y', scale='y'`などの記述から初期化されるreplace_params_dictに1対多の関係をサポートさせました．
