### PR TITLE
Fix/mixed contiguous

### DIFF
--- a/examples/cvae.ipynb
+++ b/examples/cvae.ipynb
@@ -687,7 +687,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'cvae'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "plot_number = 1\n",
     "\n",

--- a/examples/gan.ipynb
+++ b/examples/gan.ipynb
@@ -1795,7 +1795,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'gan'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "z_sample = torch.randn(64, z_dim).to(device)\n",
     "_x, _y = iter(test_loader).next()\n",

--- a/examples/glow.ipynb
+++ b/examples/glow.ipynb
@@ -820,7 +820,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'glow'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "z_sample = torch.randn(64, 3, 32, 32).to(device)\n",
     "_x, _ = iter(test_loader).next()\n",

--- a/examples/hierarchical_variational_inference.ipynb
+++ b/examples/hierarchical_variational_inference.ipynb
@@ -690,7 +690,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'hierarchical_variational_inference'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "z_sample = 0.5 * torch.randn(64, z_dim).to(device)\n",
     "_x, _ = iter(test_loader).next()\n",

--- a/examples/jmvae.ipynb
+++ b/examples/jmvae.ipynb
@@ -672,7 +672,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'jmvae'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "plot_number = 1\n",
     "\n",

--- a/examples/jmvae_poe.ipynb
+++ b/examples/jmvae_poe.ipynb
@@ -707,7 +707,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'jmvae_poe'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "plot_number = 1\n",
     "\n",

--- a/examples/m2.ipynb
+++ b/examples/m2.ipynb
@@ -823,7 +823,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'm2'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "for epoch in range(1, epochs + 1):\n",
     "    train_loss = train(epoch)\n",

--- a/examples/maximum_likelihood.ipynb
+++ b/examples/maximum_likelihood.ipynb
@@ -517,7 +517,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'maximum_likelihood'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "for epoch in range(1, epochs + 1):\n",
     "    train_loss = train(epoch)\n",

--- a/examples/mmd_vae.ipynb
+++ b/examples/mmd_vae.ipynb
@@ -637,7 +637,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'mmd_vae'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "z_sample = 0.5 * torch.randn(64, z_dim).to(device)\n",
     "_x, _ = iter(test_loader).next()\n",

--- a/examples/mvae.ipynb
+++ b/examples/mvae.ipynb
@@ -3402,7 +3402,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'mvae'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "plot_number = 1\n",
     "\n",

--- a/examples/real_nvp.ipynb
+++ b/examples/real_nvp.ipynb
@@ -543,7 +543,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'real_nvp'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "z_sample = torch.randn(64, z_dim).to(device)\n",
     "_x, _ = iter(test_loader).next()\n",

--- a/examples/real_nvp_cifar.ipynb
+++ b/examples/real_nvp_cifar.ipynb
@@ -413,7 +413,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'real_nvp_cifar'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "z_sample = torch.randn(64, 3, 32, 32).to(device)\n",
     "_x, _ = iter(test_loader).next()\n",

--- a/examples/real_nvp_cond.ipynb
+++ b/examples/real_nvp_cond.ipynb
@@ -573,7 +573,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'real_nvp_cond'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "plot_number = 5\n",
     "\n",

--- a/examples/real_nvp_toy.ipynb
+++ b/examples/real_nvp_toy.ipynb
@@ -13,6 +13,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip install sklearn\n",
+    "\n",
     "from __future__ import print_function\n",
     "import torch\n",
     "import torch.utils.data\n",

--- a/examples/vae.ipynb
+++ b/examples/vae.ipynb
@@ -738,7 +738,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'vae'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "# fix latent variable z for watching generative model improvement \n",
     "z_sample = 0.5 * torch.randn(64, z_dim).to(device)\n",

--- a/examples/vae_with_vae_class.ipynb
+++ b/examples/vae_with_vae_class.ipynb
@@ -730,7 +730,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'vae_with_vae_class'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "# fix latent variable z for watching generative model improvement \n",
     "z_sample = 0.5 * torch.randn(64, z_dim).to(device)\n",

--- a/examples/vi.ipynb
+++ b/examples/vi.ipynb
@@ -606,7 +606,7 @@
     "exp_time = dt_now.strftime('%Y%m%d_%H:%M:%S')\n",
     "v = pixyz.__version__\n",
     "nb_name = 'vi'\n",
-    "writer = SummaryWriter("runs/" + v + "." + nb_name + exp_time)\n",
+    "writer = SummaryWriter(\"runs/\" + v + \".\" + nb_name + exp_time)\n",
     "\n",
     "z_sample = 0.5 * torch.randn(64, z_dim).to(device)\n",
     "_x, _ = iter(test_loader).next()\n",

--- a/pixyz/distributions/flow_distribution.py
+++ b/pixyz/distributions/flow_distribution.py
@@ -140,7 +140,8 @@ class TransformedDistribution(Distribution):
         z : torch.Tensor
 
         """
-        z = self.flow.forward(x=x, y=y, compute_jacobian=compute_jacobian)
+        # hotfix: Suppress warnings from pytorch about mixed memory operations
+        z = self.flow.forward(x=x, y=y, compute_jacobian=compute_jacobian).contiguous()
 
         self.stored_x.clear()
         self.stored_x[hash(z)] = x
@@ -303,7 +304,8 @@ class InverseTransformedDistribution(Distribution):
         z : torch.Tensor
 
         """
-        return self.flow.forward(x=x, y=y, compute_jacobian=compute_jacobian)
+        # hotfix: Suppress warnings from pytorch about mixed memory operations
+        return self.flow.forward(x=x, y=y, compute_jacobian=compute_jacobian).contiguous()
 
     def inverse(self, z, y=None):
         """

--- a/pixyz/flows/coupling.py
+++ b/pixyz/flows/coupling.py
@@ -152,7 +152,7 @@ class AffineCoupling(Flow):
         x = x_masked + x_inv_masked * torch.exp(log_s) + t
 
         if compute_jacobian:
-            self._logdet_jacobian = log_s.view(log_s.size(0), -1).sum(-1)
+            self._logdet_jacobian = log_s.contiguous().view(log_s.size(0), -1).sum(-1)
 
         return x
 


### PR DESCRIPTION
#130 の後でレビューお願いします．

## 目的
pytorch 1.6 で生じるようになったexamples/real_nvp_cifar.ipynb, glow.ipynbのエラーを修正する

## 内容
pixyz/flowsの入出力テンソルのcontiguousについて仕様が明確でないことが原因だが，今回のエラーに関わる部分のみ明示的にcontiguousに戻してhotfixとした．