### PR TITLE
fix/Unupdated graph name of an atomic distribution

### DIFF
--- a/pixyz/distributions/distributions.py
+++ b/pixyz/distributions/distributions.py
@@ -794,7 +794,10 @@ class Distribution(nn.Module):
     @property
     def graph(self):
         if self._atomic:
-            return DistGraph().appended(atom_dist=self)
+            if not self._graph:
+                # (graph,) for escaping meta-language of nn.Module
+                self._graph = (DistGraph().appended(atom_dist=self),)
+            return self._graph[0]
         else:
             return self._graph
 

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -1,0 +1,14 @@
+from pixyz.distributions import Normal
+
+
+class TestGraph:
+    def test_rename_atomdist(self):
+        normal = Normal(var=['x'], name='p')
+        graph = normal.graph
+        assert graph.name == 'p'
+        normal.name = 'q'
+        assert graph.name == 'q'
+
+    def test_print(self):
+        normal = Normal(var=['x'], name='p')
+        print(normal.graph)


### PR DESCRIPTION
※先に`feature/add_pytest_v3`をマージしてください．

AtomicなDistributionのnameプロパティを変更しても，AtomicなDistributionを使用するグラフで変更が反映されない問題．
→ 以下の「反映されるべき」を採用

# 原因と対策
## 反映されないべき
Distributionは式木でありconst扱いするべきで，設定可能なプロパティが存在するのが間違っている

→ name.setterはMultiplyDistributionなどのoperatorを使った生成で__init__を通じた初期化ができないときに使用されているため，AtomicDistribution以外から初回のみ設定可能にすれば分かりやすいはず
　→ 初期化フラグを状態として追加したくない（わかりにくい）

## 反映されるべき
DistGraphをDistribution APIに封じ込めるためのlife spanの設計に問題がある

- MultiplyDistribution系はDistGraphをcompositionする
- AtomicDistributionはDistGraphを生成する

この設計は，DistGraphの__str__でAtomicDistribution.__repr__をnn.Moduleとして呼び出すために，DistGraphをcompositionすると無限ループするから（つまりnn.Moduleメタ機構の問題）

→ nn.Moduleのmodulesに検出されないようにcompositionする