### PR TITLE
rename DataDistribution to EmpiricalDistribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -141,10 +141,10 @@ Deterministic
     :members:
     :undoc-members:
 
-DataDistribution
+EmpiricalDistribution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: DataDistribution
+.. autoclass:: EmpiricalDistribution
     :members:
     :undoc-members:
 

--- a/examples/mmd_vae.ipynb
+++ b/examples/mmd_vae.ipynb
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pixyz.distributions import Normal, Bernoulli, DataDistribution\n",
+    "from pixyz.distributions import Normal, Bernoulli, EmpiricalDistribution\n",
     "from pixyz.losses import CrossEntropy, MMD\n",
     "from pixyz.models import Model\n",
     "from pixyz.utils import print_latex"
@@ -112,7 +112,7 @@
     "prior = Normal(loc=torch.tensor(0.), scale=torch.tensor(1.),\n",
     "               var=[\"z\"], features_shape=[z_dim], name=\"p_{prior}\").to(device)\n",
     "\n",
-    "p_data = DataDistribution([\"x\"]).to(device)\n",
+    "p_data = EmpiricalDistribution([\"x\"]).to(device)\n",
     "q_mg = (q*p_data).marginalize_var(\"x\")\n",
     "q_mg.name = \"q\""
    ]
@@ -169,7 +169,7 @@
       "Distribution:\n",
       "  q(z) = \\int q(z|x)p_{data}(x)dx\n",
       "Network architecture:\n",
-      "  DataDistribution(\n",
+      "  EmpiricalDistribution(\n",
       "    name=p_{data}, distribution_name=Data distribution,\n",
       "    var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])\n",
       "  )\n",

--- a/pixyz/distributions/__init__.py
+++ b/pixyz/distributions/__init__.py
@@ -17,7 +17,7 @@ from .custom_distributions import (
 
 from .special_distributions import (
     Deterministic,
-    DataDistribution
+    EmpiricalDistribution
 )
 
 from .distributions import (
@@ -37,7 +37,7 @@ __all__ = [
     'Distribution',
     'CustomProb',
     'Deterministic',
-    'DataDistribution',
+    'EmpiricalDistribution',
     'Normal',
     'Bernoulli',
     'RelaxedBernoulli',

--- a/pixyz/distributions/special_distributions.py
+++ b/pixyz/distributions/special_distributions.py
@@ -65,7 +65,7 @@ class Deterministic(Distribution):
         return True
 
 
-class DataDistribution(Distribution):
+class EmpiricalDistribution(Distribution):
     """
     Data distribution.
 
@@ -74,12 +74,12 @@ class DataDistribution(Distribution):
     Examples
     --------
     >>> import torch
-    >>> p = DataDistribution(var=["x"])
+    >>> p = EmpiricalDistribution(var=["x"])
     >>> print(p)
     Distribution:
       p_{data}(x)
     Network architecture:
-      DataDistribution(
+      EmpiricalDistribution(
         name=p_{data}, distribution_name=Data distribution,
         var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
       )
@@ -111,7 +111,7 @@ class DataDistribution(Distribution):
     @property
     def input_var(self):
         """
-        In DataDistribution, `input_var` is same as `var`.
+        In EmpiricalDistribution, `input_var` is same as `var`.
         """
 
         return self.var

--- a/pixyz/losses/adversarial_loss.py
+++ b/pixyz/losses/adversarial_loss.py
@@ -136,7 +136,7 @@ class AdversarialJensenShannon(AdversarialLoss):
     Examples
     --------
     >>> import torch
-    >>> from pixyz.distributions import Deterministic, DataDistribution, Normal
+    >>> from pixyz.distributions import Deterministic, EmpiricalDistribution, Normal
     >>> # Generator
     >>> class Generator(Deterministic):
     ...     def __init__(self):
@@ -166,12 +166,12 @@ class AdversarialJensenShannon(AdversarialLoss):
         (model): Linear(in_features=32, out_features=64, bias=True)
       )
     >>> # Data distribution (dummy distribution)
-    >>> p_data = DataDistribution(["x"])
+    >>> p_data = EmpiricalDistribution(["x"])
     >>> print(p_data)
     Distribution:
       p_{data}(x)
     Network architecture:
-      DataDistribution(
+      EmpiricalDistribution(
         name=p_{data}, distribution_name=Data distribution,
         var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
       )
@@ -303,7 +303,7 @@ class AdversarialKullbackLeibler(AdversarialLoss):
     Examples
     --------
     >>> import torch
-    >>> from pixyz.distributions import Deterministic, DataDistribution, Normal
+    >>> from pixyz.distributions import Deterministic, EmpiricalDistribution, Normal
     >>> # Generator
     >>> class Generator(Deterministic):
     ...     def __init__(self):
@@ -333,12 +333,12 @@ class AdversarialKullbackLeibler(AdversarialLoss):
         (model): Linear(in_features=32, out_features=64, bias=True)
       )
     >>> # Data distribution (dummy distribution)
-    >>> p_data = DataDistribution(["x"])
+    >>> p_data = EmpiricalDistribution(["x"])
     >>> print(p_data)
     Distribution:
       p_{data}(x)
     Network architecture:
-      DataDistribution(
+      EmpiricalDistribution(
         name=p_{data}, distribution_name=Data distribution,
         var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
       )
@@ -461,7 +461,7 @@ class AdversarialWassersteinDistance(AdversarialJensenShannon):
     Examples
     --------
     >>> import torch
-    >>> from pixyz.distributions import Deterministic, DataDistribution, Normal
+    >>> from pixyz.distributions import Deterministic, EmpiricalDistribution, Normal
     >>> # Generator
     >>> class Generator(Deterministic):
     ...     def __init__(self):
@@ -491,12 +491,12 @@ class AdversarialWassersteinDistance(AdversarialJensenShannon):
         (model): Linear(in_features=32, out_features=64, bias=True)
       )
     >>> # Data distribution (dummy distribution)
-    >>> p_data = DataDistribution(["x"])
+    >>> p_data = EmpiricalDistribution(["x"])
     >>> print(p_data)
     Distribution:
       p_{data}(x)
     Network architecture:
-      DataDistribution(
+      EmpiricalDistribution(
         name=p_{data}, distribution_name=Data distribution,
         var=['x'], cond_var=[], input_var=['x'], features_shape=torch.Size([])
       )

--- a/pixyz/models/gan.py
+++ b/pixyz/models/gan.py
@@ -2,7 +2,7 @@ from torch import optim
 
 from ..models.model import Model
 from ..losses import AdversarialJensenShannon
-from ..distributions import DataDistribution
+from ..distributions import EmpiricalDistribution
 
 
 class GAN(Model):
@@ -105,7 +105,7 @@ class GAN(Model):
 
         # set distributions (for training)
         distributions = [p]
-        p_data = DataDistribution(p.var)
+        p_data = EmpiricalDistribution(p.var)
 
         # set losses
         loss = AdversarialJensenShannon(p_data, p, discriminator,


### PR DESCRIPTION
Changed to a more accurate name than `DataDistribution`.