### PR TITLE
lru cache size = 1

### DIFF
--- a/pixyz/utils.py
+++ b/pixyz/utils.py
@@ -5,7 +5,7 @@ from IPython.display import Math
 import pixyz
 
 _EPSILON = 1e-07
-CACHE_SIZE = 0
+CACHE_SIZE = 1
 
 
 def set_epsilon(eps):


### PR DESCRIPTION
enabled default lru cache for pixyz Distribution