### PR TITLE
Allow scalar type parameters of DistributionBase

### DIFF
--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -1,3 +1,4 @@
+import torch
 from pixyz.distributions import Normal
 
 
@@ -12,3 +13,18 @@ class TestGraph:
     def test_print(self):
         normal = Normal(var=['x'], name='p')
         print(normal.graph)
+
+
+class TestDistributionBase:
+    def test_init_with_scalar_params(self):
+        normal = Normal(loc=0, scale=1, features_shape=[2])
+        assert normal.sample()['x'].shape == torch.Size([1, 2])
+        assert normal.features_shape == torch.Size([2])
+
+        normal = Normal(loc=0, scale=1)
+        assert normal.sample()['x'].shape == torch.Size([1])
+        assert normal.features_shape == torch.Size([])
+
+    def test_batch_n(self):
+        normal = Normal(loc=0, scale=1)
+        assert normal.sample(batch_n=3)['x'].shape == torch.Size([3])


### PR DESCRIPTION
I propose to be able to put scalar type parameters so that Distribution can be generated easily like as the previous pixyz.