### PR TITLE
Fix/graph option

### DIFF
--- a/pixyz/distributions/distributions.py
+++ b/pixyz/distributions/distributions.py
@@ -78,8 +78,9 @@ class Factor:
 
         local_input_dict = replace_dict_keys(input_dict, self.name_dict)
 
-        option = dict(self.option)
-        option.update(sample_option)
+        # Overwrite log_prob_option with self.option to give priority to local settings such as batch_n
+        option = dict(sample_option)
+        option.update(self.option)
         local_output_dict = self.dist.sample(local_input_dict, **option)
 
         # TODO: It shows return_hidden option change graphical model. This is bad operation.
@@ -100,8 +101,9 @@ class Factor:
         input_dict = get_dict_values(values, global_input_var, return_dict=True)
         local_input_dict = replace_dict_keys(input_dict, self.name_dict)
 
-        option = dict(self.option)
-        option.update(log_prob_option)
+        # Overwrite log_prob_option with self.option to give priority to local settings such as batch_n
+        option = dict(log_prob_option)
+        option.update(self.option)
         log_prob = self.dist.get_log_prob(local_input_dict, **option)
         return log_prob
 
@@ -189,7 +191,7 @@ class DistGraph(nn.Module):
         var: list of string
         """
         if not var:
-            self.global_option.update(option_dict)
+            self.global_option = option_dict
         else:
             for var_name in var:
                 for factor in self._factors_from_variable(var_name):

--- a/pixyz/distributions/distributions.py
+++ b/pixyz/distributions/distributions.py
@@ -189,6 +189,17 @@ class DistGraph(nn.Module):
         ----------
         option_dict: dict of str and any object
         var: list of string
+        Examples
+        --------
+        >>> from pixyz.distributions import Normal
+        >>> dist = Normal(var=['x'], cond_var=['y'], loc='y', scale=1) * Normal(var=['y'], loc=0, scale=1)
+        >>> # Set options only on the sampling start node
+        >>> dist.graph.set_option(dict(batch_n=4, sample_shape=(2, 3)), ['y'])
+        >>> sample = dist.sample()
+        >>> sample['y'].shape
+        torch.Size([2, 3, 4])
+        >>> sample['x'].shape
+        torch.Size([2, 3, 4])
         """
         if not var:
             self.global_option = option_dict

--- a/pixyz/distributions/exponential_distributions.py
+++ b/pixyz/distributions/exponential_distributions.py
@@ -158,11 +158,12 @@ class FactorizedBernoulli(Bernoulli):
     def distribution_name(self):
         return "FactorizedBernoulli"
 
-    def get_log_prob(self, x_dict):
+    def get_log_prob(self, x_dict, sum_features=True, feature_dims=None):
         log_prob = super().get_log_prob(x_dict, sum_features=False)
         [_x] = get_dict_values(x_dict, self._var)
         log_prob[_x == 0] = 0
-        log_prob = sum_samples(log_prob)
+        if sum_features:
+            log_prob = sum_samples(log_prob, feature_dims)
         return log_prob
 
 

--- a/pixyz/utils.py
+++ b/pixyz/utils.py
@@ -308,18 +308,20 @@ def tolist(a):
     return [a]
 
 
-def sum_samples(samples):
+def sum_samples(samples, sum_dims=None):
     """Sum a given sample across the axes.
 
     Parameters
     ----------
     samples : torch.Tensor
-        Input sample. The number of this axes is assumed to be 4 or less.
+        Input sample.
+    sum_dims : torch.Size or list of int or None
+        Dimensions to reduce. If it is None, all dimensions are summed except for the first dimension.
 
     Returns
     -------
     torch.Tensor
-        Sum over all axes except the first axis.
+        Sumed sample.
 
 
     Examples
@@ -334,16 +336,17 @@ def sum_samples(samples):
     >>> sum_samples(a).size()
     torch.Size([2])
     """
+    if sum_dims is not None:
+        if len(sum_dims) == 0:
+            return samples
+        return torch.sum(samples, dim=sum_dims)
 
     dim = samples.dim()
     if dim == 1:
         return samples
-    elif dim <= 4:
-        dim_list = list(torch.arange(samples.dim()))
-        samples = torch.sum(samples, dim=dim_list[1:])
-        return samples
-    raise ValueError("The number of sample axes must be any of 1, 2, 3, or 4, "
-                     "got %s." % dim)
+    dim_list = list(torch.arange(samples.dim()))
+    samples = torch.sum(samples, dim=dim_list[1:])
+    return samples
 
 
 def print_latex(obj):

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -14,6 +14,28 @@ class TestGraph:
         normal = Normal(var=['x'], name='p')
         print(normal.graph)
 
+    def test_set_option(self):
+        dist = Normal(var=['x'], cond_var=['y'], loc='y', scale=1) * Normal(var=['y'], loc=0, scale=1)
+        dist.graph.set_option(dict(batch_n=4, sample_shape=(2, 3)), ['y'])
+        sample = dist.sample()
+        assert sample['y'].shape == torch.Size([2, 3, 4])
+        assert sample['x'].shape == torch.Size([2, 3, 4])
+        dist.graph.set_option({}, ['y'])
+        assert dist.get_log_prob(sample,
+                                 sum_features=True, feature_dims=None).shape == torch.Size([2])
+        assert dist.get_log_prob(sample,
+                                 sum_features=False).shape == torch.Size([2, 3, 4])
+
+        # dist = Normal(var=['x'], cond_var=['y'], loc='y', scale=1) * FactorizedBernoulli(
+        #     var=['y'], probs=torch.tensor([0.3, 0.8]))
+        # dist.graph.set_option(dict(batch_n=3, sample_shape=(4,)), ['y'])
+        # sample = dist.sample()
+        # assert sample['y'].shape == torch.Size([4, 3, 2])
+        # assert sample['x'].shape == torch.Size([4, 3, 2])
+        # dist.graph.set_option(dict(), ['y'])
+        # dist.graph.set_option(dict(sum_features=True, feature_dims=[-1]))
+        # assert dist.get_log_prob(sample).shape == torch.Size([4, 3])
+
 
 class TestDistributionBase:
     def test_init_with_scalar_params(self):


### PR DESCRIPTION
## Issue
The following assertion fails and the sample shape is `torch.Size([1])`.

```
dist = Normal(var=['x'], cond_var=['y'],
      loc='y', scale=1) * Normal(var=['y'], loc=0, scale=1)
dist.graph.set_option(
      dict(batch_n=4, sample_shape=(2, 3)), ['y'])
sample = dist.sample()
assert sample['y'].shape == torch.Size([2, 3, 4])
```
This is because local options are overwritten by global options and ignored.

## Solution
- Changed the overwrite order of the option dictionary so that local options have priority
- Changed operator for `global_option` from `.update` to `=`(set) so that `global_option` can be rewritten by `set_option` method.