### PR TITLE
[WIP] Add bypass_from option to the sample method

### DIFF
--- a/pixyz/distributions/distributions.py
+++ b/pixyz/distributions/distributions.py
@@ -931,7 +931,7 @@ class Distribution(nn.Module):
     def sample(self, x_dict={}, batch_n=None, sample_shape=torch.Size(), return_all=True,
                reparam=False, bypass_from=None):
         """Sample variables of this distribution.
-        If :attr:`cond_var` is not empty, you should set inputs as :obj:`dict`.
+        If :attr:`cond_var` is not empty, you need to set x_dict containing values of :attr:`cond_var`.
 
         Parameters
         ----------

--- a/pixyz/distributions/exponential_distributions.py
+++ b/pixyz/distributions/exponential_distributions.py
@@ -123,12 +123,28 @@ class RelaxedBernoulli(Bernoulli):
             else:
                 raise ValueError()
 
-    def sample(self, x_dict={}, batch_n=None, sample_shape=torch.Size(), return_all=True, reparam=False):
+    def sample(self, x_dict={}, batch_n=None, sample_shape=torch.Size(), return_all=True, reparam=False,
+               bypass_from=None):
         # check whether the input is valid or convert it to valid dictionary.
         input_dict = self._get_input_dict(x_dict)
 
-        self.set_dist(input_dict, batch_n=batch_n, sampling=True)
-        output_dict = self.get_sample(reparam=reparam, sample_shape=sample_shape)
+        if bypass_from:
+            params = self.get_params(input_dict)
+            output_value = params[bypass_from]
+            # expand batch_n
+            if batch_n:
+                output_shape = output_value.shape
+                if output_shape[0] == 1:
+                    output_value = output_value.expand(torch.Size([batch_n]) + output_shape[1:])
+                elif output_shape[0] == batch_n:
+                    pass
+                else:
+                    raise ValueError(f"Batch shape mismatch. batch_shape from parameters: {output_shape}\n"
+                                     f" specified batch size:{batch_n}")
+            output_dict = {self.var[0]: output_value}
+        else:
+            self.set_dist(input_dict, batch_n=batch_n, sampling=True)
+            output_dict = self.get_sample(reparam=reparam, sample_shape=sample_shape)
 
         if return_all:
             x_dict = x_dict.copy()
@@ -254,12 +270,28 @@ class RelaxedCategorical(Categorical):
             else:
                 raise ValueError()
 
-    def sample(self, x_dict={}, batch_n=None, sample_shape=torch.Size(), return_all=True, reparam=False):
+    def sample(self, x_dict={}, batch_n=None, sample_shape=torch.Size(), return_all=True, reparam=False,
+               bypass_from=None):
         # check whether the input is valid or convert it to valid dictionary.
         input_dict = self._get_input_dict(x_dict)
 
-        self.set_dist(input_dict, batch_n=batch_n, sampling=True)
-        output_dict = self.get_sample(reparam=reparam, sample_shape=sample_shape)
+        if bypass_from:
+            params = self.get_params(input_dict)
+            output_value = params[bypass_from]
+            # expand batch_n
+            if batch_n:
+                output_shape = output_value.shape
+                if output_shape[0] == 1:
+                    output_value = output_value.expand(torch.Size([batch_n]) + output_shape[1:])
+                elif output_shape[0] == batch_n:
+                    pass
+                else:
+                    raise ValueError(f"Batch shape mismatch. batch_shape from parameters: {output_shape}\n"
+                                     f" specified batch size:{batch_n}")
+            output_dict = {self.var[0]: output_value}
+        else:
+            self.set_dist(input_dict, batch_n=batch_n, sampling=True)
+            output_dict = self.get_sample(reparam=reparam, sample_shape=sample_shape)
 
         if return_all:
             x_dict = x_dict.copy()

--- a/pixyz/distributions/flow_distribution.py
+++ b/pixyz/distributions/flow_distribution.py
@@ -60,9 +60,10 @@ class TransformedDistribution(Distribution):
         return self.flow.logdet_jacobian
 
     def sample(self, x_dict={}, batch_n=None, sample_shape=torch.Size(), return_all=True, reparam=False,
-               compute_jacobian=True):
+               bypass_from=None, compute_jacobian=True):
         # sample from the prior
-        sample_dict = self.prior.sample(x_dict, batch_n=batch_n, sample_shape=sample_shape, return_all=False)
+        sample_dict = self.prior.sample(x_dict, batch_n=batch_n, sample_shape=sample_shape, return_all=False,
+                                        bypass_from=bypass_from, reparam=reparam)
 
         # flow transformation
         _x = get_dict_values(sample_dict, self.flow_input_var)[0]
@@ -229,10 +230,10 @@ class InverseTransformedDistribution(Distribution):
         return self.flow.logdet_jacobian
 
     def sample(self, x_dict={}, batch_n=None, sample_shape=torch.Size(), return_all=True, reparam=False,
-               return_hidden=True):
+               bypass_from=None, return_hidden=True):
         # sample from the prior
         sample_dict = self.prior.sample(x_dict, batch_n=batch_n, sample_shape=sample_shape, return_all=False,
-                                        reparam=reparam)
+                                        reparam=reparam, bypass_from=bypass_from)
 
         # inverse flow transformation
         _z = get_dict_values(sample_dict, self.flow_output_var)

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -50,3 +50,18 @@ class TestDistributionBase:
     def test_batch_n(self):
         normal = Normal(loc=0, scale=1)
         assert normal.sample(batch_n=3)['x'].shape == torch.Size([3])
+
+    def test_bypass_from(self):
+        normal = Normal(loc=0, scale=1)
+        assert normal.sample(bypass_from='loc')['x'] == torch.tensor([0])
+        assert normal.sample(bypass_from='scale')['x'] == torch.tensor([1])
+
+        normal = Normal(loc=torch.zeros(2, 3), scale=1)
+        bypassed = normal.sample(bypass_from='loc')['x']
+        assert torch.equal(bypassed, torch.zeros(1, 2, 3))
+        bypassed = normal.sample(bypass_from='scale')['x']
+        assert torch.equal(bypassed, torch.ones(1, 2, 3))
+
+        normal = Normal(loc=torch.zeros(2, 3), scale=1)
+        bypassed = normal.sample(bypass_from='loc', batch_n=4)['x']
+        assert torch.equal(bypassed, torch.zeros(4, 2, 3))

--- a/tests/distributions/test_expornential_distributions.py
+++ b/tests/distributions/test_expornential_distributions.py
@@ -135,6 +135,10 @@ class TestRelaxedBernoulli:
     def nearly_eq(self, tensor1, tensor2):
         return abs(tensor1.item() - tensor2.item()) < 0.001
 
+    def test_bypass_from_option(self):
+        rb = RelaxedBernoulli(var=['x'], temperature=torch.tensor(0.5), probs=torch.ones(2))
+        assert torch.equal(rb.sample(bypass_from='probs')['x'], torch.ones(1, 2))
+
 
 class TestIterativeLoss:
     def test_print_latex(self):

--- a/tests/distributions/test_flow_distribution.py
+++ b/tests/distributions/test_flow_distribution.py
@@ -1,0 +1,15 @@
+import torch
+from pixyz.distributions import Normal, TransformedDistribution
+from pixyz.flows import FlowList, PlanarFlow
+
+
+class TestTransformedDistribution:
+    def test_sample_bypass_option(self):
+        x_dim = 2
+        prior = Normal(loc=torch.tensor(0.), scale=torch.tensor(1.),
+                       var=["x"], features_shape=[x_dim], name="prior")
+        f = FlowList([PlanarFlow(x_dim) for _ in range(32)])
+        q = TransformedDistribution(prior, f, var=["z"], name="q")
+        sample = q.sample(bypass_from="loc")
+        assert torch.equal(sample['x'], torch.tensor([[0., 0.]]))
+        assert sample['z'].shape == torch.Size([1, x_dim])


### PR DESCRIPTION
Waiting for merge #162

Added an option to return a value without stochastic calculation in a sample method of DistributionBase.

Example: Replace sample from the normal distribution with the mean of it.

The returned value is limited to one of the distribution's parameters.