### PR TITLE
Support old usage of bernoulli distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
     - 3.6.5
 install:
-  - pip install -e "."[test]
+  - pip install -e ".[test]"
 script:
   - pytest

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -120,7 +120,7 @@ class TestDistributionBase:
 
 class TestMixtureDistribution:
     def test_sample_mean(self):
-        dist = MixtureModel([Normal(loc=0, scale=1), Normal(loc=1, scale=1)], Categorical(probs=torch.tensor([1, 2])))
+        dist = MixtureModel([Normal(loc=0, scale=1), Normal(loc=1, scale=1)], Categorical(probs=torch.tensor([1., 2.])))
         assert dist.sample(sample_mean=True)['x'] == torch.ones(1)
 
 

--- a/tests/distributions/test_expornential_distributions.py
+++ b/tests/distributions/test_expornential_distributions.py
@@ -20,6 +20,6 @@ class TestRelaxedBernoulli:
         return abs(tensor1.item() - tensor2.item()) < 0.001
 
     def test_sample_mean(self):
-        rb = RelaxedBernoulli(var=['x'], temperature=torch.tensor(0.5), probs=torch.tensor([1 / 3., 2 / 3.]))
+        rb = RelaxedBernoulli(var=['x'], temperature=torch.tensor(0.5), probs=torch.tensor([0.5, 0.8]))
         with pytest.raises(NotImplementedError):
             rb.sample(sample_mean=True)

--- a/tests/distributions/test_expornential_distributions.py
+++ b/tests/distributions/test_expornential_distributions.py
@@ -20,6 +20,6 @@ class TestRelaxedBernoulli:
         return abs(tensor1.item() - tensor2.item()) < 0.001
 
     def test_sample_mean(self):
-        rb = RelaxedBernoulli(var=['x'], temperature=torch.tensor(0.5), probs=torch.tensor([1, 2]))
+        rb = RelaxedBernoulli(var=['x'], temperature=torch.tensor(0.5), probs=torch.tensor([1 / 3., 2 / 3.]))
         with pytest.raises(NotImplementedError):
             rb.sample(sample_mean=True)


### PR DESCRIPTION
Due to the version update of pytorch, the likelihood calculation of Bernoulli distribution is now defined only for {0, 1}.

In order to use Bernoulli distribution for modeling continuous values such as pixel luminance, `Bernoulli.log_prob` was overridden to avoid errors in the conventional usage.