### PR TITLE
Support "Automatic Mixture Precision ( AMP )"

### DIFF
--- a/pixyz/losses/iteration.py
+++ b/pixyz/losses/iteration.py
@@ -159,6 +159,9 @@ class IterativeLoss(Loss):
         loss = step_loss_sum
 
         # Restore original values
+        for key, value in self.update_value.items():
+            x_dict[key] = samples[key]
+
         x_dict.update(series_x_dict)
         x_dict.update(updated_x_dict)
         # TODO: x_dict contains no-updated variables.

--- a/pixyz/models/model.py
+++ b/pixyz/models/model.py
@@ -158,7 +158,7 @@ class Model(object):
             loss = self.loss_cls.eval(train_x_dict, **kwargs)
 
         # backprop
-        self.scale.scale(loss).backward(retain_graph=self.retain_graph)
+        self.scale(loss).backward(retain_graph=self.retain_graph)
         # loss.backward(retain_graph=self.retain_graph)
 
         if self.clip_norm:

--- a/pixyz/models/model.py
+++ b/pixyz/models/model.py
@@ -107,6 +107,7 @@ class Model(object):
         self.retain_graph = retain_graph
         self.use_amp = use_amp
 
+        # set scaler for amp
         self.scaler = torch.cuda.amp.GradScaler(enabled=self.use_amp)
 
     def __str__(self):
@@ -159,8 +160,6 @@ class Model(object):
 
         # backprop
         self.scaler.scale(loss).backward(retain_graph=self.retain_graph)
-        # self.scaler.scale(loss).backward()
-        # loss.backward(retain_graph=self.retain_graph)
 
         if self.clip_norm:
             clip_grad_norm_(self.distributions.parameters(), self.clip_norm)
@@ -169,7 +168,6 @@ class Model(object):
 
         # update params
         self.scaler.step(self.optimizer)
-        # self.optimizer.step()
 
         self.scaler.update()
 

--- a/pixyz/models/model.py
+++ b/pixyz/models/model.py
@@ -107,7 +107,7 @@ class Model(object):
         self.retain_graph = retain_graph
         self.use_amp = use_amp
 
-        self.scale = torch.cuda.amp.GradScaler(enabled=self.use_amp)
+        self.scaler = torch.cuda.amp.GradScaler(enabled=self.use_amp)
 
     def __str__(self):
         prob_text = []
@@ -158,8 +158,8 @@ class Model(object):
             loss = self.loss_cls.eval(train_x_dict, **kwargs)
 
         # backprop
-        #self.scale(loss).backward(retain_graph=self.retain_graph)
-        self.scaler.scale(loss).backward()
+        self.scale(loss).backward(retain_graph=self.retain_graph)
+        # self.scaler.scale(loss).backward()
         # loss.backward(retain_graph=self.retain_graph)
 
         if self.clip_norm:

--- a/pixyz/models/model.py
+++ b/pixyz/models/model.py
@@ -158,7 +158,8 @@ class Model(object):
             loss = self.loss_cls.eval(train_x_dict, **kwargs)
 
         # backprop
-        self.scale(loss).backward(retain_graph=self.retain_graph)
+        #self.scale(loss).backward(retain_graph=self.retain_graph)
+        self.scaler.scale(loss).backward()
         # loss.backward(retain_graph=self.retain_graph)
 
         if self.clip_norm:

--- a/pixyz/models/model.py
+++ b/pixyz/models/model.py
@@ -107,7 +107,7 @@ class Model(object):
         self.retain_graph = retain_graph
         self.use_amp = use_amp
 
-        self.scale = torch.amp.GradScaler(enabled=self.use_amp)
+        self.scale = torch.cuda.amp.GradScaler(enabled=self.use_amp)
 
     def __str__(self):
         prob_text = []

--- a/pixyz/models/model.py
+++ b/pixyz/models/model.py
@@ -158,7 +158,7 @@ class Model(object):
             loss = self.loss_cls.eval(train_x_dict, **kwargs)
 
         # backprop
-        self.scale(loss).backward(retain_graph=self.retain_graph)
+        self.scaler.scale(loss).backward(retain_graph=self.retain_graph)
         # self.scaler.scale(loss).backward()
         # loss.backward(retain_graph=self.retain_graph)
 
@@ -168,10 +168,10 @@ class Model(object):
             clip_grad_value_(self.distributions.parameters(), self.clip_value)
 
         # update params
-        self.scale.step(self.optimizer)
+        self.scaler.step(self.optimizer)
         # self.optimizer.step()
 
-        self.scale.update()
+        self.scaler.update()
 
         return loss
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     ],
     extras_require={
         'dev': ['pytest',
-                'flake8==3.9.2'
+                'flake8==3.9.2',
                 'pytest-cov',
                 'pytest-flake8',
                 'sphinx',


### PR DESCRIPTION
## What I did

- Add Automatic Mixture Precision ( AMP ) function into Model class

## What I did not

- None

## What you can do

- Memory on cuda can be reduced if use_amp argument is True in Model.

## What you can not do

- None

## Operation check

- Check cuda memory it used ( nvidia-smi )
- Sample program
```
class Normal(dists.Normal):
    def __init__(self):
        super().__init__(var=["y"], cond_var=["x"])

        self.nn = nn.Linear(1, 10000)

        self.output_loc = nn.Linear(10000, 1)
        self.output_scale = nn.Sequential(
            nn.Linear(10000, 1),
            nn.Softplus(),
        )

    def forward(self, x):
        h = self.nn(x)
        loc = self.output_loc(h)
        scale = self.output_scale(h)

        return {"loc": loc, "scale": scale}


p = Normal()
p.to("cuda")
model = Model(loss=-LogProb(p).mean(), distributions=[p], use_amp=False)

x = torch.ones(10000, 1).to("cuda")
y = torch.zeros(10000, 1).to("cuda")
loss = model.train({"x": x, "y": y})
```

- Result is like below
```
GPU RAM ( If use_amp argument is False )
1305MiB / 15360MiB

GPU RAM ( If use_amp argument is True )
737MiB / 15360MiB
```

## Reference information

- [AUTOMATIC MIXED PRECISION PACKAGE - TORCH.AMP](https://pytorch.org/docs/stable/amp.html)